### PR TITLE
Update Avalonia.* dependencies to 0.9.9

### DIFF
--- a/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/app-mvvm/AvaloniaAppTemplate.csproj
@@ -14,8 +14,8 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.0" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.0" />
+    <PackageReference Include="Avalonia" Version="0.9.9" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.9" />
   </ItemGroup>
 </Project>

--- a/app/AvaloniaAppTemplate.csproj
+++ b/app/AvaloniaAppTemplate.csproj
@@ -12,7 +12,7 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.0" />
+    <PackageReference Include="Avalonia" Version="0.9.9" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Following from [AvaloniaUI #3881](https://github.com/AvaloniaUI/Avalonia/issues/3881) I'd like to bump the default versions in this template to 0.9.9. As it currently stands, trying to run them without updating the packages manually causes segfaults on my machine.

Additionally since .NET Core 3 is end of [life](https://dotnet.microsoft.com/download/dotnet-core), I think it might make sense to bump the default target from `netcoreapp3.0` to `netcoreapp3.1`?