### PR TITLE
Add Templates for Styles and ResourceDictionary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,3 +63,19 @@ To create a new `UserControl` called `MyNewView`, in the namespace `MyApp` run:
 ```
 dotnet new avalonia.usercontrol -na MyApp -n MyNewView
 ```
+
+# Creating a new Styles list
+
+To create a new `Styles` list called `MyStyles`, run:
+
+```
+dotnet new avalonia.styles -n MyStyles
+```
+
+# Creating a new ResourceDictionary
+
+To create a new `ResourceDictionary` called `MyResources`, run:
+
+```
+dotnet new avalonia.resource -n MyResources
+```

--- a/resource-dictionary/.template.config/template.json
+++ b/resource-dictionary/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+    "author": "AvaloniaUI",
+    "classifications": [ "ui", "xaml" ],
+    "name": "Avalonia Resource Dictionary",
+    "identity": "Avalonia.ResourceDictionary",
+    "shortName": "avalonia.resource",
+    "tags": {
+        "type" : "item"
+    },
+    "sourceName": "NewResourceDictionary",
+    "primaryOutputs": [
+        { "path": "NewResourceDictionary.xaml" }
+    ],
+    "defaultName": "ResourceDictionary"
+}

--- a/resource-dictionary/NewResourceDictionary.xaml
+++ b/resource-dictionary/NewResourceDictionary.xaml
@@ -1,0 +1,4 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!-- Add Resources Here -->
+</ResourceDictionary>

--- a/style/.template.config/template.json
+++ b/style/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+    "author": "AvaloniaUI",
+    "classifications": [ "ui", "xaml" ],
+    "name": "Avalonia Styles List",
+    "identity": "Avalonia.Styles",
+    "shortName": "avalonia.styles",
+    "tags": {
+        "type" : "item"
+    },
+    "sourceName": "NewStyles",
+    "primaryOutputs": [
+        { "path": "NewStyles.xaml" }
+    ],
+    "defaultName": "Styles"
+}

--- a/style/NewStyles.xaml
+++ b/style/NewStyles.xaml
@@ -1,0 +1,10 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <!-- Add Controls for Previewer Here -->
+    </Border>
+  </Design.PreviewWith>
+
+  <!-- Add Styles Here -->
+</Styles>


### PR DESCRIPTION
While I was working on [documentation for StyleInclude](https://github.com/AvaloniaUI/avaloniaui.net/pull/183), I realised that these two templates would be helpful for creating `Styles` and `ResourceDictionary` files more quickly.