### PR TITLE
Update to Avalonia 0.10.12

### DIFF
--- a/Avalonia.Templates.csproj
+++ b/Avalonia.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>0.10.11.1</PackageVersion>
+    <PackageVersion>0.10.12</PackageVersion>
     <PackageId>Avalonia.Templates</PackageId>
     <Title>Avalonia Templates</Title>
     <Description>Templates for creating Avalonia applications and libraries.</Description>

--- a/templates/csharp/app-mvvm/App.axaml.cs
+++ b/templates/csharp/app-mvvm/App.axaml.cs
@@ -6,7 +6,7 @@ using AvaloniaAppTemplate.Views;
 
 namespace AvaloniaAppTemplate
 {
-    public class App : Application
+    public partial class App : Application
     {
         public override void Initialize()
         {

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -25,5 +25,6 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
+	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -1,8 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+	<TrimMode>copyused</TrimMode>
+	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />
@@ -10,10 +13,17 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.11" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+		<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+	<TrimmableAssembly Include="Avalonia.Themes.Default" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.11" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.11" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
   </ItemGroup>
 </Project>

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -13,8 +13,8 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-		<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
 	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
 	<TrimmableAssembly Include="Avalonia.Themes.Default" />

--- a/templates/csharp/app/App.axaml.cs
+++ b/templates/csharp/app/App.axaml.cs
@@ -4,7 +4,7 @@ using Avalonia.Markup.Xaml;
 
 namespace AvaloniaAppTemplate
 {
-    public class App : Application
+    public partial class App : Application
     {
         public override void Initialize()
         {

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -1,16 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
+	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+	<TrimMode>copyused</TrimMode>
+	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
   <ItemGroup>
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.11" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+	<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+    <TrimmableAssembly Include="Avalonia.Themes.Default" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.11" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
    </ItemGroup>
 </Project>

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -22,5 +22,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
    </ItemGroup>
 </Project>

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
 	<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
 	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
     <TrimmableAssembly Include="Avalonia.Themes.Default" />

--- a/templates/csharp/xplat/AvaloniaTest.NetCore/AvaloniaTest.NetCore.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.NetCore/AvaloniaTest.NetCore.csproj
@@ -4,8 +4,18 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>AvaloniaTest.NetCore</RootNamespace>
-    <AvaloniaVersion>0.10.11</AvaloniaVersion>
+    <AvaloniaVersion>0.10.12</AvaloniaVersion>
+	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+	<TrimMode>copyused</TrimMode>
+	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
+  <ItemGroup>
+	<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+	<TrimmableAssembly Include="Avalonia.Themes.Default" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/templates/csharp/xplat/AvaloniaTest.NetCore/AvaloniaTest.NetCore.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.NetCore/AvaloniaTest.NetCore.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
 	<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
 	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
 	<TrimmableAssembly Include="Avalonia.Themes.Default" />

--- a/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>true</Optimize>
     <WasmNativeStrip>true</WasmNativeStrip>
-	  <EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
+	<EmccCompileOptimizationFlag>-O3</EmccCompileOptimizationFlag>
     <EmccLinkOptimizationFlag>-O3</EmccLinkOptimizationFlag>
     <RunAOTCompilation>true</RunAOTCompilation>
   </PropertyGroup>

--- a/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
@@ -6,7 +6,7 @@ using AvaloniaTest.Views;
 
 namespace AvaloniaTest
 {
-    public class App : Application
+    public partial class App : Application
     {
         public override void Initialize()
         {

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -13,5 +13,6 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <AvaloniaVersion>0.10.11</AvaloniaVersion>
+    <AvaloniaVersion>0.10.12</AvaloniaVersion>
   </PropertyGroup>
   <ItemGroup>    
     <AvaloniaResource Include="Assets\**" />

--- a/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml.cs
@@ -2,17 +2,18 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
-namespace AvaloniaTest.Views;
-
-public class MainView : UserControl
+namespace AvaloniaTest.Views
 {
-    public MainView()
+    public partial class MainView : UserControl
     {
-        InitializeComponent();
-    }
+        public MainView()
+        {
+            InitializeComponent();
+        }
 
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
     }
 }

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+	<TrimMode>copyused</TrimMode>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Models\" />
@@ -17,10 +20,17 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.11" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+	<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+	<TrimmableAssembly Include="Avalonia.Themes.Default" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.11" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.11" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
 	<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
 	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
 	<TrimmableAssembly Include="Avalonia.Themes.Default" />

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -32,6 +32,5 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
-	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -32,5 +32,6 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.12" />
+	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+	<TrimMode>copyused</TrimMode>
+	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MainWindow.axaml.fs" />
@@ -12,9 +15,16 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.11" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.11" />
+	<!--This helps with theme dll-s trimming.
+	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+	<TrimmableAssembly Include="Avalonia.Themes.Default" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="0.10.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.11" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
    </ItemGroup>
 </Project>

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
 	<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
 	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
 	<TrimmableAssembly Include="Avalonia.Themes.Default" />

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -26,5 +26,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
+	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
    </ItemGroup>
 </Project>

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -26,6 +26,5 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.12" />
-	<PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
    </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates every template to use .net6.0,updates all templates to use Avalonia 0.10.12 and adds reference to NameGenerator by default.