### PR TITLE
Remove InitializeComponent implementations

### DIFF
--- a/templates/csharp/usercontrol/NewUserControl.axaml.cs
+++ b/templates/csharp/usercontrol/NewUserControl.axaml.cs
@@ -10,10 +10,5 @@ namespace AvaloniaAppTemplate.Namespace
         {
             InitializeComponent();
         }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
-        }
     }
 }

--- a/templates/csharp/window/NewWindow.axaml.cs
+++ b/templates/csharp/window/NewWindow.axaml.cs
@@ -9,16 +9,6 @@ namespace AvaloniaAppTemplate.Namespace
         public NewWindow()
         {
             InitializeComponent();
-//-:cnd:noEmit
-#if DEBUG
-            this.AttachDevTools();
-#endif
-//+:cnd:noEmit
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
     }
 }


### PR DESCRIPTION
Now, when Avalonia.NameGenerator (XamlNameReferenceGenerator) package is included, `InitializeComponent()` implementations in code-behind does hides auto-generated InitializeComponent() which can cause different WTFs and confusion like at the https://github.com/AvaloniaUI/Avalonia.NameGenerator/issues/69, so I'd suggest removing it.

It was already fixed for the `app` / `app-mvvm` but not for the `usercontrol` and `window` templates.

I've touched only csharp templates, not sure if fsharp templates are suffering from this and should be updated too, but I'm not proficient with F# and it seems none of F# templates were fixed yet, so I'm confused and would like to not touch it too.