### PR TITLE
Add `.UseReactiveUI()` call to xplat template

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
@@ -16,6 +16,7 @@ namespace AvaloniaTest.Desktop
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
-                .LogToTrace();
+                .LogToTrace()
+                .UseReactiveUI();
     }
 }


### PR DESCRIPTION
I was studying the templates and found that `xplat` is missing the `.UseReactiveUI()` call.

Related:

- #19 
- #20 