### PR TITLE
Remove nuget.config from xplat template solution items

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest.sln
+++ b/templates/csharp/xplat/AvaloniaTest.sln
@@ -17,7 +17,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
-		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
We don't have nuget.config in this template anymore so we can remove it from solution items.