### PR TITLE
Symbols may not contain spaces

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -28,7 +28,7 @@
       "replaces": "net6.0",
       "defaultValue": "net6.0"
     },
-    "MVVM Toolkit": {
+    "MVVMToolkit": {
       "type": "parameter",
       "description": "MVVM toolkit to use in the template.",
       "datatype": "choice",
@@ -46,7 +46,7 @@
     },
     "ReactiveUIToolkitChosen": {
       "type": "computed",
-      "value": "(MVVM Toolkit == \"ReactiveUI\")"
+      "value": "(MVVMToolkit == \"ReactiveUI\")"
     }
   },
   "sources": [


### PR DESCRIPTION
The `avalonia.mvvm` template fails with an error message:

> Alias cannot contain whitespace: "--MVVM Toolkit" (Parameter 'alias')