### PR TITLE
App templates choose Avalonia version in Visual Studio

### DIFF
--- a/templates/csharp/app/.template.config/ide.host.json
+++ b/templates/csharp/app/.template.config/ide.host.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "icon": "icon.png",
+  "symbolInfo": [
+    {
+      "id": "AvaloniaVersion",
+      "name": {
+        "text": "Avalonia Version"
+      },
+      "isVisible": true
+    }
+  ]
+}

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -13,5 +13,40 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    },
+    "AvaloniaVersion": {
+      "type": "parameter",
+      "description": "The target version of Avalonia NuGet packages.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "0.10.18",
+          "description": "Target 0.10.18 (Latest stable)."
+        },
+        {
+          "choice": "11.0.0-preview3",
+          "description": "Target 11.0.0-preview3"
+        }
+      ],
+      "defaultValue": "0.10.18"
+    },
+    "AvaloniaStableChosen": {
+      "type": "computed",
+      "value": "(AvaloniaVersion == \"0.10.18\")"
+    }
   }
 }

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -18,10 +18,18 @@
     <TrimmableAssembly Include="Avalonia.Themes.Default" />
   </ItemGroup>
   <ItemGroup>
+<!--#if (AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
+<!--#else-->
+    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview3" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+<!--#endif -->
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
-   </ItemGroup>
+  </ItemGroup>
 </Project>

--- a/templates/fsharp/app/.template.config/ide.host.json
+++ b/templates/fsharp/app/.template.config/ide.host.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "icon": "icon.png",
+  "symbolInfo": [
+    {
+      "id": "AvaloniaVersion",
+      "name": {
+        "text": "Avalonia Version"
+      },
+      "isVisible": true
+    }
+  ]
+}

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -13,5 +13,40 @@
   "tags": {
     "language": "F#",
     "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    },
+    "AvaloniaVersion": {
+      "type": "parameter",
+      "description": "The target version of Avalonia NuGet packages.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "0.10.18",
+          "description": "Target 0.10.18 (Latest stable)."
+        },
+        {
+          "choice": "11.0.0-preview3",
+          "description": "Target 11.0.0-preview3"
+        }
+      ],
+      "defaultValue": "0.10.18"
+    },
+    "AvaloniaStableChosen": {
+      "type": "computed",
+      "value": "(AvaloniaVersion == \"0.10.18\")"
+    }
   }
 }

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-	<!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
-	<TrimMode>copyused</TrimMode>
-	<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
+    <TrimMode>copyused</TrimMode>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="MainWindow.axaml.fs" />
@@ -15,16 +15,24 @@
     <None Remove=".gitignore" />
   </ItemGroup>
   <ItemGroup>
-	<!--This helps with theme dll-s trimming.
-	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
-	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
-	<TrimmableAssembly Include="Avalonia.Themes.Fluent" />
-	<TrimmableAssembly Include="Avalonia.Themes.Default" />
+    <!--This helps with theme dll-s trimming.
+    If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
+    https://github.com/AvaloniaUI/Avalonia/issues/5593 -->
+    <TrimmableAssembly Include="Avalonia.Themes.Fluent" />
+    <TrimmableAssembly Include="Avalonia.Themes.Default" />
   </ItemGroup>
   <ItemGroup>
+<!--#if (AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
-   </ItemGroup>
+<!--#else-->
+    <PackageReference Include="Avalonia" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview3" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview3" />
+<!--#endif -->
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR allows you to choose Avalonia NuGet packages version from the Visual Studio:
![image](https://user-images.githubusercontent.com/53405089/199234136-f6b02cce-8d79-4f24-b81d-bcdec79bef6a.png)
and from CLI by specifying -A parameter
![image](https://user-images.githubusercontent.com/53405089/199234247-3bd8713c-df16-4d02-92ff-d64b657333d2.png)

When you will specify the parameter you will get the correct template with expected NuGet version.