### PR TITLE
Added comment to clearify Design.DataContext

### DIFF
--- a/templates/csharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/csharp/app-mvvm/Views/MainWindow.axaml
@@ -9,6 +9,8 @@
         Title="AvaloniaAppTemplate">
 
     <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 

--- a/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -8,6 +8,8 @@
              Foreground="White"
              Background="#171C2C">
   <Design.DataContext>
+    <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
     <viewModels:MainViewModel />
   </Design.DataContext>
 

--- a/templates/fsharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/fsharp/app-mvvm/Views/MainWindow.axaml
@@ -9,6 +9,8 @@
         Title="AvaloniaAppTemplate">
 
     <Design.DataContext>
+        <!-- This only sets the DataContext for the previewer in an IDE,
+             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.fs) -->
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 

--- a/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -8,6 +8,8 @@
              Foreground="White"
              Background="#171C2C">
   <Design.DataContext>
+    <!-- This only sets the DataContext for the previewer in an IDE,
+         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.fs) -->
     <viewModels:MainViewModel />
   </Design.DataContext>
 


### PR DESCRIPTION
As discussed in Telegram, this adds a comment to the usages of Design.DataContext to make clear it is only used for IDE previewers. Since many beginners wonder why this does not set the actual DataContext.