### PR TITLE
Added choice for net7.0

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -15,13 +15,6 @@
     "type": "project"
   },
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -15,6 +15,13 @@
     "type": "project"
   },
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
@@ -29,7 +36,7 @@
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
+      "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
     "MVVMToolkit": {

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -23,6 +23,10 @@
         {
           "choice": "net6.0",
           "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
       "replaces": "net6.0",

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/templates/csharp/app/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/csharp/app/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -15,13 +15,6 @@
     "type": "project"
   },
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -15,6 +15,13 @@
     "type": "project"
   },
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
@@ -29,7 +36,7 @@
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
+      "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
     "AvaloniaVersion": {

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -23,6 +23,10 @@
         {
           "choice": "net6.0",
           "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
       "replaces": "net6.0",

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/templates/csharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/csharp/xplat/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/csharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/csharp/xplat/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -15,13 +15,6 @@
     "type": "project"
   },
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -13,5 +13,24 @@
   "tags": {
     "language": "C#",
     "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    }
   }
 }

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -15,22 +15,25 @@
     "type": "project"
   },
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
           "choice": "net7.0",
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
-      "defaultValue": "net6.0"
+      "replaces": "FrameworkParameter",
+      "defaultValue": "net7.0"
     }
   }
 }

--- a/templates/csharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-android</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>com.CompanyName.AvaloniaTest</ApplicationId>

--- a/templates/csharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-android</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-android</TargetFramework>
+    <TargetFramework>FrameworkParameter-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <ApplicationId>com.CompanyName.AvaloniaTest</ApplicationId>

--- a/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>

--- a/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>

--- a/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
     <OutputType>Exe</OutputType>

--- a/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <WasmMainJSPath>AppBundle\main.js</WasmMainJSPath>
     <OutputType>Exe</OutputType>

--- a/templates/csharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-ios</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-ios</TargetFramework>
+    <TargetFramework>FrameworkParameter-ios</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>

--- a/templates/csharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-ios</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-ios</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -13,5 +13,24 @@
   "tags": {
     "language": "F#",
     "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    }
   }
 }

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -15,13 +15,6 @@
     "type": "project"
   },
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -15,6 +15,13 @@
     "type": "project"
   },
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
@@ -29,7 +36,7 @@
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
+      "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
     "AvaloniaVersion": {

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/templates/fsharp/app/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/fsharp/app/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -15,13 +15,6 @@
     "type": "project"
   },
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -15,6 +15,13 @@
     "type": "project"
   },
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
@@ -29,7 +36,7 @@
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
+      "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
     "AvaloniaVersion": {

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -23,6 +23,10 @@
         {
           "choice": "net6.0",
           "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
         }
       ],
       "replaces": "net6.0",

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/templates/fsharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/xplat/.template.config/dotnetcli.host.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+      "longName": "framework"
+    }
+  },
+  "usageExamples": [
+    ""
+  ]
+}

--- a/templates/fsharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/xplat/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     }

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -13,5 +13,24 @@
     "type": "project"
   },
   "sourceName": "AvaloniaTest",
-  "preferNameDirectory": true
+  "preferNameDirectory": true,
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        },
+        {
+          "choice": "net7.0",
+          "description": "Target net7.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    }
+  }
 }

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -15,13 +15,6 @@
   "sourceName": "AvaloniaTest",
   "preferNameDirectory": true,
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -15,22 +15,25 @@
   "sourceName": "AvaloniaTest",
   "preferNameDirectory": true,
   "symbols": {
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
           "choice": "net7.0",
           "description": "Target net7.0"
         }
       ],
-      "replaces": "net6.0",
-      "defaultValue": "net6.0"
+      "replaces": "FrameworkParameter",
+      "defaultValue": "net7.0"
     }
   }
 }

--- a/templates/fsharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.fsproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-android</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-android</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-android</TargetFramework>
     <SupportedOSPlatformVersion>30</SupportedOSPlatformVersion>
     <ApplicationId>com.CompanyName.AvaloniaTest</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>

--- a/templates/fsharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Android/AvaloniaTest.Android.fsproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-android</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-android</TargetFramework>
+    <TargetFramework>FrameworkParameter-android</TargetFramework>
     <SupportedOSPlatformVersion>30</SupportedOSPlatformVersion>
     <ApplicationId>com.CompanyName.AvaloniaTest</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>

--- a/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
 

--- a/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
 

--- a/templates/fsharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.fsproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <!--Temporal hack that fixes compilation in VS-->
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <EmccTotalMemory>16777216</EmccTotalMemory>

--- a/templates/fsharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Web/AvaloniaTest.Web.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <!--Temporal hack that fixes compilation in VS-->
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <EmccTotalMemory>16777216</EmccTotalMemory>

--- a/templates/fsharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.fsproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0-ios</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-ios</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-ios</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>

--- a/templates/fsharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.iOS/AvaloniaTest.iOS.fsproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-ios</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter-ios</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride-ios</TargetFramework>
+    <TargetFramework>FrameworkParameter-ios</TargetFramework>
     <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <ProvisioningType>manual</ProvisioningType>
     <Nullable>enable</Nullable>

--- a/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">FrameworkParameter</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This adds the target framework choice for net7.0 additionally to the net6.0 for all templates.

One thing I noticed is that on CLI the parameter would be --Framework instead of --framework.
Should I adjust that like e.g. [it is done for the WPF template](https://github.com/dotnet/wpf/blob/main/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/dotnetcli.host.json)?

Also should the test script also test both frameworks?