### PR TITLE
Avalonia version choice for MVVM templates

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/csharp/app-mvvm/.template.config/ide.host.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "icon": "icon.png",
+  "symbolInfo": [
+    {
+      "id": "AvaloniaVersion",
+      "name": {
+        "text": "Avalonia Version"
+      },
+      "isVisible": true
+    },
+    {
+      "id": "MVVMToolkit",
+      "name": {
+        "text": "MVVM Toolkit"
+      },
+      "isVisible": true
+    }
+  ]
+}

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -47,6 +47,26 @@
     "ReactiveUIToolkitChosen": {
       "type": "computed",
       "value": "(MVVMToolkit == \"ReactiveUI\")"
+    },
+    "AvaloniaVersion": {
+      "type": "parameter",
+      "description": "The target version of Avalonia NuGet packages.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "0.10.18",
+          "description": "Target 0.10.18 (Latest stable)."
+        },
+        {
+          "choice": "11.0.0-preview4",
+          "description": "Target 11.0.0-preview4"
+        }
+      ],
+      "defaultValue": "0.10.18"
+    },
+    "AvaloniaStableChosen": {
+      "type": "computed",
+      "value": "(AvaloniaVersion == \"0.10.18\")"
     }
   },
   "sources": [

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -62,6 +62,7 @@
           "description": "Target 11.0.0-preview4"
         }
       ],
+      "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "0.10.18"
     },
     "AvaloniaStableChosen": {

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+<!--#if (AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
@@ -27,6 +28,18 @@
     <!--#else-->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <!--#endif -->
+<!--#else-->
+    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
+    <!--#if (ReactiveUIToolkitChosen) -->
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
+    <!--#else-->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+    <!--#endif -->
+<!--#endif -->
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -18,28 +18,18 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--#if (AvaloniaStableChosen) -->
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
+    <!--#if (!AvaloniaStableChosen) -->
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (ReactiveUIToolkitChosen) -->
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="AvaloniaVersionTemplateParameter" />
     <!--#else-->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <!--#endif -->
-<!--#else-->
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
-    <!--#if (ReactiveUIToolkitChosen) -->
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
-    <!--#else-->
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <!--#endif -->
-<!--#endif -->
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -42,6 +42,7 @@
           "description": "Target 11.0.0-preview4"
         }
       ],
+      "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "0.10.18"
     },
     "AvaloniaStableChosen": {

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -15,18 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--#if (AvaloniaStableChosen) -->
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
+    <!--#if (!AvaloniaStableChosen) -->
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
-<!--#else-->
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
-<!--#endif -->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/ide.host.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json.schemastore.org/ide.host",
+  "icon": "icon.png",
+  "symbolInfo": [
+    {
+      "id": "AvaloniaVersion",
+      "name": {
+        "text": "Avalonia Version"
+      },
+      "isVisible": true
+    }
+  ]
+}

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -42,6 +42,7 @@
           "description": "Target 11.0.0-preview4"
         }
       ],
+      "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "0.10.18"
     },
     "AvaloniaStableChosen": {

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -13,5 +13,40 @@
   "tags": {
     "language": "F#",
     "type": "project"
+  },
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0"
+        }
+      ],
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
+    },
+    "AvaloniaVersion": {
+      "type": "parameter",
+      "description": "The target version of Avalonia NuGet packages.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "0.10.18",
+          "description": "Target 0.10.18 (Latest stable)."
+        },
+        {
+          "choice": "11.0.0-preview4",
+          "description": "Target 11.0.0-preview4"
+        }
+      ],
+      "defaultValue": "0.10.18"
+    },
+    "AvaloniaStableChosen": {
+      "type": "computed",
+      "value": "(AvaloniaVersion == \"0.10.18\")"
+    }
   }
 }

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -26,19 +26,14 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--#if (AvaloniaStableChosen) -->
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
+    <!--#if (!AvaloniaStableChosen) -->
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
-<!--#else-->
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
-<!--#endif -->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -26,10 +26,19 @@
   </ItemGroup>
 
   <ItemGroup>
+<!--#if (AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia" Version="0.10.18" />
     <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
+<!--#else-->
+    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
+<!--#endif -->
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -42,6 +42,7 @@
           "description": "Target 11.0.0-preview4"
         }
       ],
+      "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "0.10.18"
     },
     "AvaloniaStableChosen": {

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -21,17 +21,13 @@
   </ItemGroup>
 
   <ItemGroup>
-<!--#if (AvaloniaStableChosen) -->
-    <PackageReference Include="Avalonia" Version="0.10.18" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
+    <!--#if (!AvaloniaStableChosen) -->
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.18" />
-<!--#else-->
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
-<!--#endif -->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds also Avalonia version choice to the MVVM templates and simplifies the choosing for all.
With the old way it would be nested ``#if``s for the MVVM templates.
With the new way the version has also now only to be specified for the choices and not again in the csproj files.

If the simplified way is not liked I can also revert to the old ``#if/ #elseif``  syntax, so only the change that the Avalonia version is added to the MVVM templates remains (first commit).