### PR TITLE
Lower case names for template paramters on CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Available parameters:
 
 *By default*: net6.0
 
-``-A, --AvaloniaVersion``
+``-av, --avalonia-version``
 
 *Description*: The target version of Avalonia NuGet packages.
 
@@ -78,7 +78,7 @@ Available parameters:
 
 *By default*: net6.0
 
-``-A, --AvaloniaVersion``
+``-av, --avalonia-version``
 
 *Description*: The target version of Avalonia NuGet packages.
 
@@ -86,7 +86,7 @@ Available parameters:
 
 *By default*: 0.10.18
 
-``-M, --MVVMToolkit``
+``-m, --mvvm``
 
 *Description*: MVVM toolkit to use in the template.
 

--- a/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -3,9 +3,15 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "AvaloniaVersion": {
+      "longName": "avalonia-version"
+    },
+    "MVVMToolkit": {
+      "longName": "mvvm"
     }
   },
   "usageExamples": [
-    ""
+    "--mvvm communitytoolkit"
   ]
 }

--- a/templates/csharp/app/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app/.template.config/dotnetcli.host.json
@@ -3,6 +3,9 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "AvaloniaVersion": {
+      "longName": "avalonia-version"
     }
   },
   "usageExamples": [

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -3,6 +3,9 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "AvaloniaVersion": {
+      "longName": "avalonia-version"
     }
   },
   "usageExamples": [

--- a/templates/fsharp/app/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app/.template.config/dotnetcli.host.json
@@ -3,6 +3,9 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "AvaloniaVersion": {
+      "longName": "avalonia-version"
     }
   },
   "usageExamples": [


### PR DESCRIPTION
This improves the CLI experience by making the parameter names lowercase for the CLI.