### PR TITLE
Added MVVM choice for F# MVVM template

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -52,6 +52,10 @@
       "type": "computed",
       "value": "(MVVMToolkit == \"ReactiveUI\")"
     },
+    "CommunityToolkitChosen": {
+      "type": "computed",
+      "value": "(MVVMToolkit == \"CommunityToolkit\")"
+    },
     "AvaloniaVersion": {
       "type": "parameter",
       "description": "The target version of Avalonia NuGet packages.",

--- a/templates/csharp/app-mvvm/App.axaml.cs
+++ b/templates/csharp/app-mvvm/App.axaml.cs
@@ -1,6 +1,6 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-#if (!ReactiveUIToolkitChosen)
+#if (CommunityToolkitChosen)
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 #endif
@@ -21,7 +21,7 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-#if (!ReactiveUIToolkitChosen)
+#if (CommunityToolkitChosen)
             // Line below is needed to remove Avalonia data validation.
             // Without this line you will get duplicate validations from both Avalonia and CT
             ExpressionObserver.DataValidators.RemoveAll(x => x is DataAnnotationsValidationPlugin);

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -27,7 +27,7 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (ReactiveUIToolkitChosen) -->
     <PackageReference Include="Avalonia.ReactiveUI" Version="AvaloniaVersionTemplateParameter" />
-    <!--#else-->
+    <!--#elif (CommunityToolkitChosen)-->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <!--#endif -->
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.5.1" />

--- a/templates/csharp/app-mvvm/Program.cs
+++ b/templates/csharp/app-mvvm/Program.cs
@@ -19,10 +19,10 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-#if (!ReactiveUIToolkitChosen)
-            .LogToTrace();
-#else
+#if (ReactiveUIToolkitChosen)
             .LogToTrace()
             .UseReactiveUI();
+#else
+            .LogToTrace();
 #endif
 }

--- a/templates/csharp/app-mvvm/ViewModels/MainWindowViewModel.cs
+++ b/templates/csharp/app-mvvm/ViewModels/MainWindowViewModel.cs
@@ -1,10 +1,10 @@
-﻿#if (!ReactiveUIToolkitChosen)
+﻿#if (CommunityToolkitChosen)
 using CommunityToolkit.Mvvm.ComponentModel;
 #endif
 
 namespace AvaloniaAppTemplate.ViewModels;
 
-#if (!ReactiveUIToolkitChosen)
+#if (CommunityToolkitChosen)
 public class MainWindowViewModel : ObservableObject
 #else
 public class MainWindowViewModel : ViewModelBase

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -6,9 +6,12 @@
     },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
+    },
+    "MVVMToolkit": {
+      "longName": "mvvm"
     }
   },
   "usageExamples": [
-    ""
+    "--mvvm communitytoolkit"
   ]
 }

--- a/templates/fsharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/ide.host.json
@@ -8,6 +8,13 @@
         "text": "Avalonia Version"
       },
       "isVisible": true
+    },
+    {
+      "id": "MVVMToolkit",
+      "name": {
+        "text": "MVVM Toolkit"
+      },
+      "isVisible": true
     }
   ]
 }

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -32,6 +32,30 @@
       "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
+    "MVVMToolkit": {
+      "type": "parameter",
+      "description": "MVVM toolkit to use in the template.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "ReactiveUI",
+          "description": "Choose ReactiveUI as MVVM toolkit in the template."
+        },
+        {
+          "choice": "CommunityToolkit",
+          "description": "Choose CommunityToolkit as MVVM toolkit in the template."
+        }
+      ],
+      "defaultValue": "ReactiveUI"
+    },
+    "ReactiveUIToolkitChosen": {
+      "type": "computed",
+      "value": "(MVVMToolkit == \"ReactiveUI\")"
+    },
+    "CommunityToolkitChosen": {
+      "type": "computed",
+      "value": "(MVVMToolkit == \"CommunityToolkit\")"
+    },
     "AvaloniaVersion": {
       "type": "parameter",
       "description": "The target version of Avalonia NuGet packages.",
@@ -53,5 +77,17 @@
       "type": "computed",
       "value": "(AvaloniaVersion == \"0.10.18\")"
     }
-  }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!ReactiveUIToolkitChosen)",
+          "exclude": [
+            "ViewModels/ViewModelBase.fs"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/templates/fsharp/app-mvvm/App.axaml.fs
+++ b/templates/fsharp/app-mvvm/App.axaml.fs
@@ -2,6 +2,10 @@ namespace AvaloniaAppTemplate
 
 open Avalonia
 open Avalonia.Controls.ApplicationLifetimes
+#if (CommunityToolkitChosen)
+open Avalonia.Data.Core
+open Avalonia.Data.Core.Plugins
+#endif
 open Avalonia.Markup.Xaml
 open AvaloniaAppTemplate.ViewModels
 open AvaloniaAppTemplate.Views
@@ -13,6 +17,13 @@ type App() =
             AvaloniaXamlLoader.Load(this)
 
     override this.OnFrameworkInitializationCompleted() =
+
+#if (CommunityToolkitChosen)
+        // Line below is needed to remove Avalonia data validation.
+        // Without this line you will get duplicate validations from both Avalonia and CT
+        ExpressionObserver.DataValidators.RemoveAll(fun x -> x :? DataAnnotationsValidationPlugin) |> ignore
+#endif
+
         match this.ApplicationLifetime with
         | :? IClassicDesktopStyleApplicationLifetime as desktop ->
              desktop.MainWindow <- MainWindow(DataContext = MainWindowViewModel())

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -13,7 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
+<!--#if (ReactiveUIToolkitChosen) -->
     <Compile Include="ViewModels\ViewModelBase.fs" />
+<!--#endif -->
     <Compile Include="ViewModels\MainWindowViewModel.fs" />
     <Compile Include="Views\MainWindow.axaml.fs" />
     <Compile Include="ViewLocator.fs" />
@@ -33,7 +35,11 @@
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
+    <!--#if (ReactiveUIToolkitChosen) -->
     <PackageReference Include="Avalonia.ReactiveUI" Version="AvaloniaVersionTemplateParameter" />
-    <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
+    <!--#elif (CommunityToolkitChosen)-->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+    <!--#endif -->
+    <PackageReference Include="XamlNameReferenceGenerator" Version="1.5.1" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app-mvvm/Program.fs
+++ b/templates/fsharp/app-mvvm/Program.fs
@@ -2,7 +2,9 @@
 
 open System
 open Avalonia
+#if (ReactiveUIToolkitChosen)
 open Avalonia.ReactiveUI
+#endif
 open AvaloniaAppTemplate
 
 module Program =
@@ -13,7 +15,9 @@ module Program =
             .Configure<App>()
             .UsePlatformDetect()
             .LogToTrace(areas = Array.empty)
+#if (ReactiveUIToolkitChosen)
             .UseReactiveUI()
+#endif
 
     [<EntryPoint; STAThread>]
     let main argv =

--- a/templates/fsharp/app-mvvm/ViewLocator.fs
+++ b/templates/fsharp/app-mvvm/ViewLocator.fs
@@ -1,9 +1,14 @@
 namespace AvaloniaAppTemplate
 
 open System
+#if (!ReactiveUIToolkitChosen)
+open System.ComponentModel
+#endif
 open Avalonia.Controls
 open Avalonia.Controls.Templates
+#if (ReactiveUIToolkitChosen)
 open AvaloniaAppTemplate.ViewModels
+#endif
 
 type ViewLocator() =
     interface IDataTemplate with
@@ -15,5 +20,9 @@ type ViewLocator() =
                 upcast TextBlock(Text = sprintf "Not Found: %s" name)
             else
                 downcast Activator.CreateInstance(typ)
-
+                
+#if (ReactiveUIToolkitChosen)
         member this.Match(data) = data :? ViewModelBase
+#else
+        member this.Match(data) = data :? INotifyPropertyChanged
+#endif

--- a/templates/fsharp/app-mvvm/ViewModels/MainWindowViewModel.fs
+++ b/templates/fsharp/app-mvvm/ViewModels/MainWindowViewModel.fs
@@ -1,6 +1,14 @@
 ﻿namespace AvaloniaAppTemplate.ViewModels
 
+#if (CommunityToolkitChosen)
+open CommunityToolkit.Mvvm.ComponentModel;
+#endif
+
 type MainWindowViewModel() =
+#if (CommunityToolkitChosen)
+    inherit ObservableObject()
+#else
     inherit ViewModelBase()
+#endif
 
     member this.Greeting = "Welcome to Avalonia!"

--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -118,5 +118,7 @@ Test-Template "avalonia.mvvm" "AvaloniaMvvm" "F#" "f" "net6.0" $binlog
 Test-Template "avalonia.mvvm" "AvaloniaMvvm" "F#" "f" "net7.0" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "av" "0.10.18" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "av" "11.0.0-preview4" $binlog
+Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "m" "ReactiveUI" $binlog
+Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "m" "CommunityToolkit" $binlog
 
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "f" "net7.0" $binlog


### PR DESCRIPTION
This adds the same choice for MVVM framework that the C# MVVM template has to F#.
Fixes https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/108