### PR TITLE
Removed XamlNameReferenceGenerator from F# templates

### DIFF
--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -40,6 +40,5 @@
     <!--#elif (CommunityToolkitChosen)-->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <!--#endif -->
-    <PackageReference Include="XamlNameReferenceGenerator" Version="1.5.1" />
   </ItemGroup>
 </Project>

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -28,6 +28,5 @@
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />
-    <PackageReference Include="XamlNameReferenceGenerator" Version="1.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The XamlNameReferenceGenerator reference does nothing for F#, it is also not included in the xplat template, this removes it from the app and app-mvvm template as well