### PR TITLE
Post action: opening main files in editor

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -72,6 +72,10 @@
     "AvaloniaStableChosen": {
       "type": "computed",
       "value": "(AvaloniaVersion == \"0.10.18\")"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
   },
   "sources": [
@@ -84,6 +88,30 @@
           ]
         }
       ]
+    }
+  ],
+  "primaryOutputs": [
+    { "path": "AvaloniaAppTemplate.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "ViewModels/MainWindowViewModel.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Views/MainWindow.axaml"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainWindow and MainWindowViewModel in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
     }
   ]
 }

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -52,6 +52,34 @@
     "AvaloniaStableChosen": {
       "type": "computed",
       "value": "(AvaloniaVersion == \"0.10.18\")"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
+  },
+  "primaryOutputs": [
+    { "path": "AvaloniaAppTemplate.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MainWindow.axaml.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MainWindow.axaml"
   }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainWindow in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -27,6 +27,34 @@
       ],
       "replaces": "FrameworkParameter",
       "defaultValue": "net7.0"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
-  }
+  },
+  "primaryOutputs": [
+    { "path": "AvaloniaTest/AvaloniaTest.csproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "AvaloniaTest/ViewModels/MainViewModel.cs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "AvaloniaTest/Views/MainView.axaml"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainView and MainViewModel in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -52,6 +52,34 @@
     "AvaloniaStableChosen": {
       "type": "computed",
       "value": "(AvaloniaVersion == \"0.10.18\")"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
-  }
+  },
+  "primaryOutputs": [
+    { "path": "AvaloniaAppTemplate.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "ViewModels/MainWindowViewModel.fs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "Views/MainWindow.axaml"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainWindow and MainWindowViewModel in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -52,6 +52,34 @@
     "AvaloniaStableChosen": {
       "type": "computed",
       "value": "(AvaloniaVersion == \"0.10.18\")"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
-  }
+  },
+  "primaryOutputs": [
+    { "path": "AvaloniaAppTemplate.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MainWindow.axaml.fs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "MainWindow.axaml"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainWindow in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -27,6 +27,34 @@
       ],
       "replaces": "FrameworkParameter",
       "defaultValue": "net7.0"
+    },
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
     }
-  }
+  },
+  "primaryOutputs": [
+    { "path": "AvaloniaTest/AvaloniaTest.fsproj" },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "AvaloniaTest/ViewModels/MainViewModel.fs"
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "path": "AvaloniaTest/Views/MainView.axaml"
+    }
+  ],
+  "postActions": [
+    {
+      "id": "editor",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens MainView and MainViewModel in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1;2"
+      },
+      "continueOnError": true
+    }
+  ]
 }


### PR DESCRIPTION
This adds primary outputs and post actions to open the most relevant files in editor when the template is used in VS or Rider.
Depending on the template type it will open the following files after creating a project:
app: MainWindows.axaml, MainWindow.axaml.(cs|fs) (this is the same as the WPF templates)
app-mvvm: MainWindow.axaml, MainWindowViewModel.(cs|fs)
xplat: MainView.axaml, MainViewModel.(cs|fs)

Note: somehow it does not open the .axaml files for F# projects on Rider, on VS everything works fine.

The WPF and the other dotnet sdk project templates have besides this open in editor action also the [nuget restore action](https://github.com/dotnet/wpf/blob/6c820231562d46d2ef8b2b3197a5709dbfa77d54/packaging/Microsoft.Dotnet.Wpf.ProjectTemplates/content/WpfApplication-CSharp/.template.config/template.json#L118).
Should we add this as well? (They also have a `--no-restore` parameter for CLI)

Off topic: I noticed Rider [does not support custom template parameters at all currently](https://youtrack.jetbrains.com/issue/RIDER-16759/Support-parameters-in-custom-project-templates), so choosing avalonia version or MVVM toolkit does not work (only target framework is supported)