### PR TITLE
Default namespace for item templates

### DIFF
--- a/templates/csharp/templatedcontrol/.template.config/template.json
+++ b/templates/csharp/templatedcontrol/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {

--- a/templates/csharp/usercontrol/.template.config/template.json
+++ b/templates/csharp/usercontrol/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {

--- a/templates/csharp/window/.template.config/template.json
+++ b/templates/csharp/window/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {


### PR DESCRIPTION
This infers the root namespace of the project (by default the name of the project) an item template is added to and uses this for the item template when no one is specified with the `--namespace` flag. It also does not give an error if the item template is created outside of a project.

This sadly only works for C#.

Maybe in future this could be improved to include also the folder structure, e.g "AvaloniaApplication.Views" but that would require changes in the template SDK.