### PR TITLE
Revert post actions for xplat templates

### DIFF
--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -27,34 +27,6 @@
       ],
       "replaces": "FrameworkParameter",
       "defaultValue": "net7.0"
-    },
-    "HostIdentifier": {
-      "type": "bind",
-      "binding": "HostIdentifier"
     }
-  },
-  "primaryOutputs": [
-    { "path": "AvaloniaTest/AvaloniaTest.csproj" },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "AvaloniaTest/ViewModels/MainViewModel.cs"
-    },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "AvaloniaTest/Views/MainView.axaml"
-    }
-  ],
-  "postActions": [
-    {
-      "id": "editor",
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "description": "Opens MainView and MainViewModel in the editor",
-      "manualInstructions": [ ],
-      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-      "args": {
-        "files": "1;2"
-      },
-      "continueOnError": true
-    }
-  ]
+  }
 }

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -27,34 +27,6 @@
       ],
       "replaces": "FrameworkParameter",
       "defaultValue": "net7.0"
-    },
-    "HostIdentifier": {
-      "type": "bind",
-      "binding": "HostIdentifier"
     }
-  },
-  "primaryOutputs": [
-    { "path": "AvaloniaTest/AvaloniaTest.fsproj" },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "AvaloniaTest/ViewModels/MainViewModel.fs"
-    },
-    {
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "path": "AvaloniaTest/Views/MainView.axaml"
-    }
-  ],
-  "postActions": [
-    {
-      "id": "editor",
-      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
-      "description": "Opens MainView and MainViewModel in the editor",
-      "manualInstructions": [ ],
-      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
-      "args": {
-        "files": "1;2"
-      },
-      "continueOnError": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Somewhy post actions for xplat templates excludes all projects besides one. Thats everything you will see after you have generated avalonia.xplat from VS and it works the same with F#
![image](https://user-images.githubusercontent.com/53405089/211712547-e3a180f9-4eca-4eb8-b646-6f3ae2389e88.png)
Though when you generate this template from CLI it works ok.
@Mrxx99 it would really help if you will fix that,sorry i didn't notice during reviewing