### PR TITLE
Fixed primary outputs for xplat templates

### DIFF
--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -35,6 +35,10 @@
   },
   "primaryOutputs": [
     { "path": "AvaloniaTest/AvaloniaTest.csproj" },
+    { "path": "AvaloniaTest.Android/AvaloniaTest.Android.csproj" },
+    { "path": "AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj" },
+    { "path": "AvaloniaTest.iOS/AvaloniaTest.iOS.csproj" },
+    { "path": "AvaloniaTest.Web/AvaloniaTest.Web.csproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "AvaloniaTest/ViewModels/MainViewModel.cs"
@@ -52,7 +56,7 @@
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
-        "files": "1;2"
+        "files": "5;6"
       },
       "continueOnError": true
     }

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -35,6 +35,10 @@
   },
   "primaryOutputs": [
     { "path": "AvaloniaTest/AvaloniaTest.fsproj" },
+    { "path": "AvaloniaTest.Android/AvaloniaTest.Android.fsproj" },
+    { "path": "AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj" },
+    { "path": "AvaloniaTest.iOS/AvaloniaTest.iOS.fsproj" },
+    { "path": "AvaloniaTest.Web/AvaloniaTest.Web.fsproj" },
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "AvaloniaTest/ViewModels/MainViewModel.fs"
@@ -52,7 +56,7 @@
       "manualInstructions": [ ],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
-        "files": "1;2"
+        "files": "5;6"
       },
       "continueOnError": true
     }


### PR DESCRIPTION
This re-adds the post actions for the xplat templates that were faulty introduces in #153 (sorry for that) and removed in #156
I have fixed the issues that were there and tested it in VS 2022 and Rider 2022.2.4, it now works the same as for the other project templates.