### PR TITLE
Add nuget restore post actions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,11 @@ Available parameters:
 *Options*: **0.10.18**, **11.0.0-preview4**
 
 *By default*: 0.10.18
-                                   
+
+``-no-restore``
+
+*Description*: If specified, skips the automatic restore of the project on create.
+
 # Creating a new MVVM Application
 
 MVVM is the recommended pattern for creating Avalonia applications. The MVVM application template
@@ -93,6 +97,10 @@ Available parameters:
 *Options*: **ReactiveUI**, **CommunityToolkit**
 
 *By default*: ReactiveUI
+
+``-no-restore``
+
+*Description*: If specified, skips the automatic restore of the project on create.
 
 # Creating a new Cross-Platform application
 

--- a/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
     "Framework": {
       "longName": "framework"
     },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     },

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -32,6 +32,12 @@
       "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    },
     "MVVMToolkit": {
       "type": "parameter",
       "description": "MVVM toolkit to use in the template.",
@@ -94,6 +100,16 @@
     }
   ],
   "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
     {
       "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",

--- a/templates/csharp/app/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
     "Framework": {
       "longName": "framework"
     },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     }

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -32,6 +32,12 @@
       "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    },
     "AvaloniaVersion": {
       "type": "parameter",
       "description": "The target version of Avalonia NuGet packages.",
@@ -67,9 +73,19 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "path": "MainWindow.axaml"
-  }
+    }
   ],
   "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
     {
       "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
     "Framework": {
       "longName": "framework"
     },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     },

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -32,6 +32,12 @@
       "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    },
     "MVVMToolkit": {
       "type": "parameter",
       "description": "MVVM toolkit to use in the template.",
@@ -94,6 +100,16 @@
     }
   ],
   "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
     {
       "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",

--- a/templates/fsharp/app/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app/.template.config/dotnetcli.host.json
@@ -4,6 +4,10 @@
     "Framework": {
       "longName": "framework"
     },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     }

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -32,6 +32,12 @@
       "replaces": "FrameworkParameter",
       "defaultValue": "net6.0"
     },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    },
     "AvaloniaVersion": {
       "type": "parameter",
       "description": "The target version of Avalonia NuGet packages.",
@@ -70,6 +76,16 @@
     }
   ],
   "postActions": [
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    },
     {
       "id": "editor",
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",


### PR DESCRIPTION
This adds a [nuget restore post action](https://github.com/dotnet/templating/wiki/Post-Action-Registry#restore-nuget-packages) to the project templates.
It is currently not added for the xplat templates because there the experience is not great if you do not have all the workloads installed as e.g. Android, iOS and web fail
<details>
  <summary>CLI output</summary>

  ![grafik](https://user-images.githubusercontent.com/33566379/212391091-af01fd99-1a56-4bf8-a86f-f02ef5a8b960.png)
</details>

I wanted to specifiy that only the shared and Desktop project should be restored, but there seems to be a bug in templating so this does not work (https://github.com/dotnet/templating/issues/5922).

We could already merge it without the xplat templates if you want and add the xplat templates later, when the issue is fixed in the SDK.