### PR TITLE
Default namespace for F# item templates

### DIFF
--- a/templates/fsharp/templatedcontrol/.template.config/template.json
+++ b/templates/fsharp/templatedcontrol/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {

--- a/templates/fsharp/usercontrol/.template.config/template.json
+++ b/templates/fsharp/usercontrol/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {

--- a/templates/fsharp/window/.template.config/template.json
+++ b/templates/fsharp/window/.template.config/template.json
@@ -16,8 +16,20 @@
   "symbols": {
     "namespace": {
       "description": "Namespace for the generated code",
-      "replaces": "AvaloniaAppTemplate.Namespace",
       "type": "parameter"
+    },
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace"
+    },
+    "NamespaceReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "namespace",
+        "fallbackVariableName": "DefaultNamespace"
+      },
+      "replaces": "AvaloniaAppTemplate.Namespace"
     }
   },
   "tags": {


### PR DESCRIPTION
In my pull request for default namespace for item templates (only C#) #154 I wrote that this approach only works for C#.
I was wrong, I just noticed that you will only get this result
![grafik](https://user-images.githubusercontent.com/33566379/212762882-72830139-c21c-4400-a9fc-07fb82efeb28.png)
when the project was not built yet, after `dotnet build` was executed it works fine as expected.
I also noticed that for C# this is the exact same behavior.
When this message appears the default namespace "AvaloniaAppTemplate.Namespace" is used.