### PR TITLE
Removed global.json from SolutionItems in xplat solution

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest.sln
+++ b/templates/csharp/xplat/AvaloniaTest.sln
@@ -16,7 +16,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3DA99C4E-89E3-4049-9C22-0A7EC60D83D8}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		global.json = global.json
 	EndProjectSection
 EndProject
 Global

--- a/templates/fsharp/xplat/AvaloniaTest.sln
+++ b/templates/fsharp/xplat/AvaloniaTest.sln
@@ -15,7 +15,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3DA99C4E-89E3-4049-9C22-0A7EC60D83D8}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		global.json = global.json
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
The solution for the xplat projects was still including the not anymore existing global.json in the SolutionItems.
This lead to VS still displaying it but giving an error when trying to open it.
This PR removes it.