### PR TITLE
Added post action to open added item templates files in editor

### DIFF
--- a/templates/csharp/templatedcontrol/.template.config/template.json
+++ b/templates/csharp/templatedcontrol/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "C#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens TemplatedControl in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/csharp/usercontrol/.template.config/template.json
+++ b/templates/csharp/usercontrol/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "C#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens UserControl in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/csharp/window/.template.config/template.json
+++ b/templates/csharp/window/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "C#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens Window in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/templatedcontrol/.template.config/template.json
+++ b/templates/fsharp/templatedcontrol/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "F#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens TemplatedControl in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/usercontrol/.template.config/template.json
+++ b/templates/fsharp/usercontrol/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "F#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens UserControl in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/fsharp/window/.template.config/template.json
+++ b/templates/fsharp/window/.template.config/template.json
@@ -35,5 +35,18 @@
   "tags": {
     "language": "F#",
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens Window in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0;1"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/resource-dictionary/.template.config/template.json
+++ b/templates/resource-dictionary/.template.config/template.json
@@ -13,5 +13,18 @@
   "sourceName": "NewResourceDictionary",
   "tags": {
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens ResourceDictionary in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0"
+        },
+        "continueOnError": true
+    }
+  ]
 }

--- a/templates/styles/.template.config/template.json
+++ b/templates/styles/.template.config/template.json
@@ -13,5 +13,18 @@
   "sourceName": "NewStyles",
   "tags": {
     "type": "item"
-  }
+  },
+  "postActions": [
+    {
+        "id": "editor",
+        "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+        "description": "Opens Style in the editor.",
+        "manualInstructions": [],
+        "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+        "args": {
+            "files": "0"
+        },
+        "continueOnError": true
+    }
+  ]
 }


### PR DESCRIPTION
This add post actions to open the created files from item templates in the editor, similar how it is done in project templates, that is also what the MAUI templates do. tested in VS2022