### PR TITLE
Remove Google fonts reference

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest.Browser/AppBundle/index.html
+++ b/templates/csharp/xplat/AvaloniaTest.Browser/AppBundle/index.html
@@ -10,7 +10,6 @@
     <link rel="modulepreload" href="./dotnet.js" />
     <link rel="modulepreload" href="./avalonia.js" />
     <link rel="stylesheet" href="./app.css" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
 </head>
 
 <body style="margin: 0px; overflow: hidden">

--- a/templates/fsharp/xplat/AvaloniaTest.Browser/AppBundle/index.html
+++ b/templates/fsharp/xplat/AvaloniaTest.Browser/AppBundle/index.html
@@ -10,7 +10,6 @@
     <link rel="modulepreload" href="./dotnet.js" />
     <link rel="modulepreload" href="./avalonia.js" />
     <link rel="stylesheet" href="./app.css" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
 </head>
 
 <body style="margin: 0px; overflow: hidden">


### PR DESCRIPTION
The index.html of the browser project reference the google-fonts URL, but it seems to have no impact on the template as removing them does not change anything.
Also I think is better to not add these by default, there are also some issues with pinging google fonts without consent of the user in some countries, e.g. see here: https://www.theregister.com/2022/01/31/website_fine_google_fonts_gdpr/ (and there were much more fines in Austria and Germany)