### PR TITLE
Make MainWindowViewModel partial when used with CommunityToolkit.Mvvm

### DIFF
--- a/templates/csharp/app-mvvm/ViewModels/MainWindowViewModel.cs
+++ b/templates/csharp/app-mvvm/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,10 @@
 ﻿namespace AvaloniaAppTemplate.ViewModels;
 
+#if (CommunityToolkitChosen)
+public partial class MainWindowViewModel : ViewModelBase
+#else
 public class MainWindowViewModel : ViewModelBase
+#endif
 {
     public string Greeting => "Welcome to Avalonia!";
 }


### PR DESCRIPTION
When using CommunityToolkit.Mvvm it is very likely that the source generator for ObservableProperties are used, which requires the ViewModel to be partial, this makes it a bit easier because it is already done for the MainWindowViewModel.