### PR TITLE
Remove conditions in App.axaml for xplat templates

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest/App.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/App.axaml
@@ -1,18 +1,10 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
-             x:Class="AvaloniaTest.App">
-             //#else
              x:Class="AvaloniaTest.App"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
-        <FluentTheme Mode="Light"/>
-        //#else
         <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>

--- a/templates/fsharp/xplat/AvaloniaTest/App.axaml
+++ b/templates/fsharp/xplat/AvaloniaTest/App.axaml
@@ -1,18 +1,10 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
-             x:Class="AvaloniaTest.App">
-             //#else
              x:Class="AvaloniaTest.App"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
-        <FluentTheme Mode="Light"/>
-        //#else
         <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>


### PR DESCRIPTION
This removes the conditions to differentiate between avalonia stabel and preview for the App.axaml file of the xplat templates, as they don't have this parameter so they are.

One person in Avalonia Telegram chat had problems that these conditions were not resolved (but it did work fine for me).