### PR TITLE
Added Avalonia.Fonts.Inter package

### DIFF
--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (!AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="AvaloniaVersionTemplateParameter" />
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />

--- a/templates/csharp/app-mvvm/Program.cs
+++ b/templates/csharp/app-mvvm/Program.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia;
+#if (!AvaloniaStableChosen)
+using Avalonia.Fonts.Inter;
+#endif
 #if (ReactiveUIToolkitChosen)
 using Avalonia.ReactiveUI;
 #endif
@@ -19,6 +22,9 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
+#if (!AvaloniaStableChosen)
+            .WithInterFont()
+#endif
 #if (ReactiveUIToolkitChosen)
             .LogToTrace()
             .UseReactiveUI();

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (!AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="AvaloniaVersionTemplateParameter" />
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />

--- a/templates/csharp/app/Program.cs
+++ b/templates/csharp/app/Program.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia;
+#if (!AvaloniaStableChosen)
+using Avalonia.Fonts.Inter;
+#endif
 using System;
 
 namespace AvaloniaAppTemplate;
@@ -16,5 +19,8 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
+#if (!AvaloniaStableChosen)
+            .WithInterFont()
+#endif
             .LogToTrace();
 }

--- a/templates/csharp/xplat/AvaloniaTest.Android/SplashActivity.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Android/SplashActivity.cs
@@ -4,6 +4,7 @@ using Android.OS;
 using Application = Android.App.Application;
 using Avalonia;
 using Avalonia.Android;
+using Avalonia.Fonts.Inter;
 using Avalonia.ReactiveUI;
 
 namespace AvaloniaTest.Android;
@@ -14,6 +15,7 @@ public class SplashActivity : AvaloniaSplashActivity<App>
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
         return base.CustomizeAppBuilder(builder)
+            .WithInterFont()
             .UseReactiveUI();
     }
 

--- a/templates/csharp/xplat/AvaloniaTest.Browser/Program.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Browser/Program.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Browser;
+using Avalonia.Fonts.Inter;
 using Avalonia.ReactiveUI;
 using AvaloniaTest;
 
@@ -10,6 +11,7 @@ using AvaloniaTest;
 internal partial class Program
 {
     private static async Task Main(string[] args) => await BuildAvaloniaApp()
+            .WithInterFont()
             .UseReactiveUI()
             .StartBrowserAppAsync("out");
 

--- a/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia;
+using Avalonia.Fonts.Inter;
 using Avalonia.ReactiveUI;
 
 namespace AvaloniaTest.Desktop;
@@ -17,6 +18,7 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            .WithInterFont()
             .LogToTrace()
             .UseReactiveUI();
 }

--- a/templates/csharp/xplat/AvaloniaTest.iOS/AppDelegate.cs
+++ b/templates/csharp/xplat/AvaloniaTest.iOS/AppDelegate.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.iOS;
 using Avalonia.Media;
+using Avalonia.Fonts.Inter;
 using Avalonia.ReactiveUI;
 
 namespace AvaloniaTest.iOS;
@@ -16,6 +17,8 @@ public partial class AppDelegate : AvaloniaAppDelegate<App>
 {
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
-        return builder.UseReactiveUI();
+        return base.CustomizeAppBuilder(builder)
+            .WithInterFont()
+            .UseReactiveUI();
     }
 }

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (!AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="AvaloniaVersionTemplateParameter" />
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />

--- a/templates/fsharp/app-mvvm/Program.fs
+++ b/templates/fsharp/app-mvvm/Program.fs
@@ -2,10 +2,12 @@
 
 open System
 open Avalonia
+#if (!AvaloniaStableChosen)
+open Avalonia.Fonts.Inter
+#endif
 #if (ReactiveUIToolkitChosen)
 open Avalonia.ReactiveUI
 #endif
-open AvaloniaAppTemplate
 
 module Program =
 
@@ -14,6 +16,9 @@ module Program =
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
+#if (!AvaloniaStableChosen)
+            .WithInterFont()
+#endif
             .LogToTrace(areas = Array.empty)
 #if (ReactiveUIToolkitChosen)
             .UseReactiveUI()

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
     <!--#if (!AvaloniaStableChosen) -->
     <PackageReference Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="AvaloniaVersionTemplateParameter" />
     <!--#endif -->
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="AvaloniaVersionTemplateParameter" />

--- a/templates/fsharp/app/Program.fs
+++ b/templates/fsharp/app/Program.fs
@@ -2,7 +2,9 @@
 
 open System
 open Avalonia
-open AvaloniaAppTemplate
+#if (!AvaloniaStableChosen)
+open Avalonia.Fonts.Inter
+#endif
 
 module Program =
 
@@ -11,6 +13,9 @@ module Program =
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
+#if (!AvaloniaStableChosen)
+            .WithInterFont()
+#endif
             .LogToTrace(areas = Array.empty)
 
     [<EntryPoint; STAThread>]

--- a/templates/fsharp/xplat/AvaloniaTest.Android/Activities.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.Android/Activities.fs
@@ -2,6 +2,8 @@ namespace AvaloniaTest.Android
 open Android.App
 open Android.Content
 open Android.Content.PM
+open Avalonia.Fonts.Inter
+open Avalonia.ReactiveUI
 open Android.OS
 type Application = Android.App.Application
 
@@ -23,7 +25,9 @@ type SplashActivity() =
     inherit  AvaloniaSplashActivity<App>()
 
     override _.CustomizeAppBuilder(builder) =
-        base.CustomizeAppBuilder(builder);
+        base.CustomizeAppBuilder(builder)
+            .WithInterFont()
+            .UseReactiveUI()
 
     override x.OnResume() =
         base.OnResume()

--- a/templates/fsharp/xplat/AvaloniaTest.Browser/Program.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.Browser/Program.fs
@@ -1,6 +1,7 @@
 open System.Runtime.Versioning
 open Avalonia
 open Avalonia.Browser
+open Avalonia.Fonts.Inter
 open Avalonia.ReactiveUI
 
 open AvaloniaTest
@@ -18,6 +19,7 @@ module Program =
     let main argv =
         task {
             do! (buildAvaloniaApp()
+            .WithInterFont()
             .UseReactiveUI()
             .StartBrowserAppAsync("out"))
         }

--- a/templates/fsharp/xplat/AvaloniaTest.Desktop/Program.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.Desktop/Program.fs
@@ -1,6 +1,7 @@
 namespace AvaloniaTest.Desktop
 open System
 open Avalonia
+open Avalonia.Fonts.Inter
 open Avalonia.ReactiveUI
 open AvaloniaTest
 
@@ -11,6 +12,7 @@ module Program =
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
+            .WithInterFont()
             .LogToTrace(areas = Array.empty)
             .UseReactiveUI()
 

--- a/templates/fsharp/xplat/AvaloniaTest.iOS/AppDelegate.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.iOS/AppDelegate.fs
@@ -1,9 +1,16 @@
 namespace AvaloniaTest.iOS
 open Foundation
 open Avalonia.iOS
+open Avalonia.Fonts.Inter
+open Avalonia.ReactiveUI
 
 // The UIApplicationDelegate for the application. This class is responsible for launching the 
 // User Interface of the application, as well as listening (and optionally responding) to 
 // application events from iOS.
 type [<Register("AppDelegate")>] AppDelegate() =
     inherit AvaloniaAppDelegate<AvaloniaTest.App>()
+
+    override _.CustomizeAppBuilder(builder) =
+        base.CustomizeAppBuilder(builder)
+            .WithInterFont()
+            .UseReactiveUI()

--- a/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />


### PR DESCRIPTION
This adds the Avalonia.Fonts.Inter package to all project types.

Some F# projects were missing UseReactiveUI, this adds this aswell (can be removed if this should be a separate PR)

Fixes #188