### PR TITLE
No conditions in AXAML files

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -96,6 +96,27 @@
       "binding": "HostIdentifier"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(AvaloniaStableChosen)",
+          "exclude": [
+            "App.v11.axaml"
+          ]
+        },
+        {
+          "condition": "(!AvaloniaStableChosen)",
+          "exclude": [
+            "App.axaml"
+          ]
+        }
+      ],
+      "rename": {
+        "App.v11.axaml": "App.axaml"
+      }
+    }
+  ],
   "primaryOutputs": [
     { "path": "AvaloniaAppTemplate.csproj" },
     {

--- a/templates/csharp/app-mvvm/App.axaml
+++ b/templates/csharp/app-mvvm/App.axaml
@@ -1,18 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
              x:Class="AvaloniaAppTemplate.App">
-             //#else
-             x:Class="AvaloniaAppTemplate.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
         <FluentTheme Mode="Light"/>
-        //#else
-        <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>

--- a/templates/csharp/app-mvvm/App.v11.axaml
+++ b/templates/csharp/app-mvvm/App.v11.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AvaloniaAppTemplate.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -72,6 +72,27 @@
       "binding": "HostIdentifier"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(AvaloniaStableChosen)",
+          "exclude": [
+            "App.v11.axaml"
+          ]
+        },
+        {
+          "condition": "(!AvaloniaStableChosen)",
+          "exclude": [
+            "App.axaml"
+          ]
+        }
+      ],
+      "rename": {
+        "App.v11.axaml": "App.axaml"
+      }
+    }
+  ],
   "primaryOutputs": [
     { "path": "AvaloniaAppTemplate.csproj" },
     {

--- a/templates/csharp/app/App.axaml
+++ b/templates/csharp/app/App.axaml
@@ -1,18 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
              x:Class="AvaloniaAppTemplate.App">
-             //#else
-             x:Class="AvaloniaAppTemplate.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
         <FluentTheme Mode="Light"/>
-        //#else
-        <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>

--- a/templates/csharp/app/App.v11.axaml
+++ b/templates/csharp/app/App.v11.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AvaloniaAppTemplate.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -96,6 +96,27 @@
       "binding": "HostIdentifier"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(AvaloniaStableChosen)",
+          "exclude": [
+            "App.v11.axaml"
+          ]
+        },
+        {
+          "condition": "(!AvaloniaStableChosen)",
+          "exclude": [
+            "App.axaml"
+          ]
+        }
+      ],
+      "rename": {
+        "App.v11.axaml": "App.axaml"
+      }
+    }
+  ],
   "primaryOutputs": [
     { "path": "AvaloniaAppTemplate.fsproj" },
     {

--- a/templates/fsharp/app-mvvm/App.axaml
+++ b/templates/fsharp/app-mvvm/App.axaml
@@ -1,18 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
              x:Class="AvaloniaAppTemplate.App">
-             //#else
-             x:Class="AvaloniaAppTemplate.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
         <FluentTheme Mode="Light"/>
-        //#else
-        <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>

--- a/templates/fsharp/app-mvvm/App.v11.axaml
+++ b/templates/fsharp/app-mvvm/App.v11.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AvaloniaAppTemplate.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -72,6 +72,27 @@
       "binding": "HostIdentifier"
     }
   },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(AvaloniaStableChosen)",
+          "exclude": [
+            "App.v11.axaml"
+          ]
+        },
+        {
+          "condition": "(!AvaloniaStableChosen)",
+          "exclude": [
+            "App.axaml"
+          ]
+        }
+      ],
+      "rename": {
+        "App.v11.axaml": "App.axaml"
+      }
+    }
+  ],
   "primaryOutputs": [
     { "path": "AvaloniaAppTemplate.fsproj" },
     {

--- a/templates/fsharp/app/App.axaml
+++ b/templates/fsharp/app/App.axaml
@@ -1,18 +1,8 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             //#if (AvaloniaStableChosen)
              x:Class="AvaloniaAppTemplate.App">
-             //#else
-             x:Class="AvaloniaAppTemplate.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
-             //#endif
 
     <Application.Styles>
-        //#if (AvaloniaStableChosen)
         <FluentTheme Mode="Light"/>
-        //#else
-        <FluentTheme />
-        //#endif
     </Application.Styles>
 </Application>

--- a/templates/fsharp/app/App.v11.axaml
+++ b/templates/fsharp/app/App.v11.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="AvaloniaAppTemplate.App"
+             RequestedThemeVariant="Default">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>


### PR DESCRIPTION
Removes all conditions in AXAML files (App.axaml) because the used syntax is not supported anymore with newer .NET SDK (currently latest preview), as it was changed to support the XML comment syntax as it is for XAML files. The new syntax can't be used here yet, as users may still have older .NET SDKs.

Additional context:
https://github.com/dotnet/templating/issues/6409

II guess only after .NET 6 or 7 is out of support theconditions (with the new syntax) can be used again in AXAML files.