### PR TITLE
Fixed AssemblyIdentity in app.manifest for app and mvvm templates

### DIFF
--- a/templates/csharp/app-mvvm/app.manifest
+++ b/templates/csharp/app-mvvm/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embeded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="1.0.0.0" name="AvaloniaTest.Desktop"/>
+  <assemblyIdentity version="1.0.0.0" name="AvaloniaAppTemplate.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/templates/csharp/app/app.manifest
+++ b/templates/csharp/app/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embeded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="1.0.0.0" name="AvaloniaTest.Desktop"/>
+  <assemblyIdentity version="1.0.0.0" name="AvaloniaAppTemplate.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/templates/fsharp/app-mvvm/app.manifest
+++ b/templates/fsharp/app-mvvm/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embeded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="1.0.0.0" name="AvaloniaTest.Desktop"/>
+  <assemblyIdentity version="1.0.0.0" name="AvaloniaAppTemplate.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/templates/fsharp/app/app.manifest
+++ b/templates/fsharp/app/app.manifest
@@ -3,7 +3,7 @@
   <!-- This manifest is used on Windows only.
        Don't remove it as it might cause problems with window transparency and embedded controls.
        For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
-  <assemblyIdentity version="1.0.0.0" name="AvaloniaTest.Desktop"/>
+  <assemblyIdentity version="1.0.0.0" name="AvaloniaAppTemplate.Desktop"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>


### PR DESCRIPTION
The assemblyIdentity in app.manifest was wrong for app and mvvm templates it was not repaced with the created apps name.