### PR TITLE
Added powershell script to re-install templates easily

### DIFF
--- a/install-dev-templates.ps1
+++ b/install-dev-templates.ps1
@@ -1,0 +1,5 @@
+dotnet new uninstall Avalonia.Templates
+Remove-Item bin/**/*.nupkg
+$result = dotnet pack | select-string "Successfully created package '(.*)'" -AllMatches
+$package = $result.Matches.Groups[1]
+dotnet new install $package


### PR DESCRIPTION
When developing the templates you have to often unistall the templates, building the package and re-install.
This simplifies it with a single script.