### PR TITLE
Assign ViewModels as DataContext to created Views in MVVM templates

### DIFF
--- a/templates/csharp/app-mvvm/ViewLocator.cs
+++ b/templates/csharp/app-mvvm/ViewLocator.cs
@@ -21,7 +21,9 @@ public class ViewLocator : IDataTemplate
 
         if (type != null)
         {
-            return (Control)Activator.CreateInstance(type)!;
+            var control = (Control)Activator.CreateInstance(type)!;
+            control.DataContext = data;
+            return control;
         }
         
         return new TextBlock { Text = "Not Found: " + name };

--- a/templates/fsharp/app-mvvm/ViewLocator.fs
+++ b/templates/fsharp/app-mvvm/ViewLocator.fs
@@ -17,6 +17,8 @@ type ViewLocator() =
                 if isNull typ then
                     upcast TextBlock(Text = sprintf "Not Found: %s" name)
                 else
-                    downcast Activator.CreateInstance(typ)
+                    let view = Activator.CreateInstance(typ) :?> IControl
+                    view.DataContext <- data
+                    view
                 
         member this.Match(data) = data :? ViewModelBase

--- a/templates/fsharp/app-mvvm/ViewLocator.fs
+++ b/templates/fsharp/app-mvvm/ViewLocator.fs
@@ -17,7 +17,7 @@ type ViewLocator() =
                 if isNull typ then
                     upcast TextBlock(Text = sprintf "Not Found: %s" name)
                 else
-                    let view = Activator.CreateInstance(typ) :?> IControl
+                    let view = Activator.CreateInstance(typ) :?> Control
                     view.DataContext <- data
                     view
                 


### PR DESCRIPTION
Usually when you try to get a specific Control based on a ViewModel, you want the VM to be assigned to the View as its DataContext.