### PR TITLE
Show repository as mainly C# and not HTML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
change should make `HTML` disappear as the main type of this repo:
![image](https://github.com/user-attachments/assets/9130794d-c774-4f67-935f-ba98499a96c0)

`C#` should then show, as the second largest portion, by type.

**Please note:** may take a few minutes post-merge for the repo to show as `C#`
![image](https://github.com/user-attachments/assets/1546624f-fc10-45dd-ae3e-9c75dbbfd08f)