### PR TITLE
install-dev-templates edit

### DIFF
--- a/install-dev-templates.ps1
+++ b/install-dev-templates.ps1
@@ -1,5 +1,16 @@
 dotnet new uninstall Avalonia.Templates
 Remove-Item bin/**/*.nupkg
-$result = dotnet pack | select-string "Successfully created package '(.*)'" -AllMatches
-$package = $result.Matches.Groups[1]
-dotnet new install $package
+
+dotnet pack
+# Search Directory
+$directoryPath = ".\bin\Release"
+
+$latestNupkgFile = Get-ChildItem -Path $directoryPath -Recurse -Filter "*.nupkg" |
+                   Where-Object { -not $_.PSIsContainer } |
+                   Sort-Object LastWriteTime -Descending |
+                   Select-Object -First 1
+
+if ($latestNupkgFile) {
+  $latestNupkgPath = $latestNupkgFile.FullName
+  dotnet new install $latestNupkgPath
+}


### PR DESCRIPTION
The way we relied on the number of deleted files was to use the 
is difficult to use if it hasn't already been created.
 Also, for some users, PowerShell's logs may not be in English. 
The dotnet pack is more reliable because it takes the most recently created files.