### PR TITLE
Remove ViewModel to View assignment after control creation in F# MVVM template

### DIFF
--- a/templates/fsharp/app-mvvm/ViewLocator.fs
+++ b/templates/fsharp/app-mvvm/ViewLocator.fs
@@ -17,8 +17,6 @@ type ViewLocator() =
                 if isNull typ then
                     upcast TextBlock(Text = sprintf "Not Found: %s" name)
                 else
-                    let view = Activator.CreateInstance(typ) :?> Control
-                    view.DataContext <- data
-                    view
+                    downcast Activator.CreateInstance(typ)
                 
         member this.Match(data) = data :? ViewModelBase


### PR DESCRIPTION
This reverts the change introduced in #238. It was already partially reverted in #277, this PR updates the F# template to also use the old version.