### PR TITLE
Disable CheckEolWorkloads on CI

### DIFF
--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -95,7 +95,7 @@ function Create-And-Build {
     Exec { dotnet new $template -o output/$lang/$folderName -$parameterName $value -lang $lang }
 
     # Build
-    Exec { dotnet build output/$lang/$folderName -bl:$bl }
+    Exec { dotnet build output/$lang/$folderName -bl:$bl -p:CheckEolWorkloads=false }
 }
 
 # Clear file system from possible previous runs


### PR DESCRIPTION
Because of https://github.com/dotnet/macios/issues/24057, the build now fails.

Even though the .NET SDK itself is pinned, workloads are always restored to their latest version.
Work around that on CI.

I hate workloads.
I hate workloads.
