### PR TITLE
Add RequiresUnreferencedCode to the ViewLocator, with a helpful Url

### DIFF
--- a/templates/csharp/app-mvvm/ViewLocator.cs
+++ b/templates/csharp/app-mvvm/ViewLocator.cs
@@ -1,13 +1,19 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using AvaloniaAppTemplate.ViewModels;
 
 namespace AvaloniaAppTemplate;
 
+/// <summary>
+/// Given a view model, returns the corresponding view if possible.
+/// </summary>
+[RequiresUnreferencedCode(
+    "Default implementation of ViewLocator involves reflection which may be trimmed away.",
+    Url = "https://docs.avaloniaui.net/docs/concepts/view-locator")]
 public class ViewLocator : IDataTemplate
 {
-
     public Control? Build(object? param)
     {
         if (param is null)

--- a/templates/csharp/xplat/AvaloniaTest/ViewLocator.cs
+++ b/templates/csharp/xplat/AvaloniaTest/ViewLocator.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using AvaloniaTest.ViewModels;
 
 namespace AvaloniaTest;
 
+/// <summary>
+/// Given a view model, returns the corresponding view if possible.
+/// </summary>
+[RequiresUnreferencedCode(
+    "Default implementation of ViewLocator involves reflection which may be trimmed away.",
+    Url = "https://docs.avaloniaui.net/docs/concepts/view-locator")]
 public class ViewLocator : IDataTemplate
 {
     public Control? Build(object? param)


### PR DESCRIPTION
Adds RequiresUnreferencedCode that will create a warning if user builds trimmable/aot application with default locator.
And includes documentation link, where alternative options are explained. See https://github.com/AvaloniaUI/avalonia-docs/pull/750

Closes https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/289