### PR TITLE
Remove "--compiled-bindings" parameter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,6 @@ dotnet new avalonia.app -o MyApp
 |-----------|-------------|---------|---------|
 | `-f`, `--framework` | The target framework for the project. | `net10.0`, `net9.0`, `net8.0` | `net10.0` |
 | `-av`, `--avalonia-version` | The target version of Avalonia NuGet packages. | | `12.0.5` |
-| `-cb`, `--compiled-bindings` | Enable CompiledBindings by default (11.0+). See [documentation](https://docs.avaloniaui.net/docs/data-binding/compiledbindings). | `true`, `false` | `true` |
 | `--no-restore` | If specified, skips the automatic restore of the project on create. | | |
 
 ## Creating a new MVVM Application
@@ -61,7 +60,6 @@ dotnet new avalonia.mvvm -o MyApp
 |-----------|-------------|---------|---------|
 | `-f`, `--framework` | The target framework for the project. | `net10.0`, `net9.0`, `net8.0` | `net10.0` |
 | `-av`, `--avalonia-version` | The target version of Avalonia NuGet packages. | | `12.0.5` |
-| `-cb`, `--compiled-bindings` | Enable CompiledBindings by default (11.0+). See [documentation](https://docs.avaloniaui.net/docs/data-binding/compiledbindings). | `true`, `false` | `true` |
 | `-m`, `--mvvm` | MVVM toolkit to use in the template. | `ReactiveUI`, `CommunityToolkit` | `CommunityToolkit` |
 | `-rvl`, `--remove-view-locator` | Remove the default ViewLocator. Useful for code trimming scenarios as the default ViewLocator is not trimming-friendly. | `true`, `false` | `false` |
 | `--no-restore` | If specified, skips the automatic restore of the project on create. | | |
@@ -79,7 +77,6 @@ This template creates an application that works on Desktop, Browser and Mobile (
 | Parameter | Description | Options | Default |
 |-----------|-------------|---------|---------|
 | `-av`, `--avalonia-version` | The target version of Avalonia NuGet packages. | | `12.0.5` |
-| `-cb`, `--compiled-bindings` | Enable CompiledBindings by default. See [documentation](https://docs.avaloniaui.net/docs/data-binding/compiledbindings). | `true`, `false` | `true` |
 | `-m`, `--mvvm` | MVVM toolkit to use in the template. | `ReactiveUI`, `CommunityToolkit` | `CommunityToolkit` |
 | `-rvl`, `--remove-view-locator` | Remove the default ViewLocator. Useful for code trimming scenarios as the default ViewLocator is not trimming-friendly. | `true`, `false` | `false` |
 | `-cpm` | Use Central Package Management (CPM). If disabled, `Directory.Build.props` will be created with the shared Avalonia version. | `true`, `false` | `true` |

--- a/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -16,9 +16,6 @@
     },
     "MVVMToolkit": {
       "longName": "mvvm"
-    },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
     }
   },
   "usageExamples": [

--- a/templates/csharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/csharp/app-mvvm/.template.config/ide.host.json
@@ -17,13 +17,6 @@
       "isVisible": true
     },
     {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
-    },
-    {
       "id": "RemoveViewLocator",
       "name": {
         "text": "Remove View Locator"

--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -73,13 +73,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "RemoveViewLocator": {
       "type": "parameter",
       "description": "Defines if your app will use default ViewLocator made by Avalonia Team or you are planning to use a custom one. Removing ViewLocator may be useful in code trimming scenarios. Default ViewLocator is not trimming-friendly.",

--- a/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app-mvvm/AvaloniaAppTemplate.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/csharp/app/.template.config/dotnetcli.host.json
+++ b/templates/csharp/app/.template.config/dotnetcli.host.json
@@ -10,9 +10,6 @@
     },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
-    },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
     }
   },
   "usageExamples": [

--- a/templates/csharp/app/.template.config/ide.host.json
+++ b/templates/csharp/app/.template.config/ide.host.json
@@ -8,13 +8,6 @@
         "text": "Avalonia Version"
       },
       "isVisible": false
-    },
-    {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
     }
   ]
 }

--- a/templates/csharp/app/.template.config/template.json
+++ b/templates/csharp/app/.template.config/template.json
@@ -49,13 +49,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/templates/csharp/app/AvaloniaAppTemplate.csproj
+++ b/templates/csharp/app/AvaloniaAppTemplate.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/csharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/csharp/xplat/.template.config/dotnetcli.host.json
@@ -7,9 +7,6 @@
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
-    },
     "MVVMToolkit": {
       "longName": "mvvm"
     },

--- a/templates/csharp/xplat/.template.config/ide.host.json
+++ b/templates/csharp/xplat/.template.config/ide.host.json
@@ -24,13 +24,6 @@
       "isVisible": true
     },
     {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
-    },
-    {
       "id": "RemoveViewLocator",
       "name": {
         "text": "Remove View Locator"

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -117,13 +117,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "RemoveViewLocator": {
       "type": "parameter",
       "description": "Defines if your app will use default ViewLocator made by Avalonia Team or you are planning to use a custom one. Removing ViewLocator may be useful in code trimming scenarios. Default ViewLocator is not trimming-friendly.",

--- a/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
+++ b/templates/csharp/xplat/AvaloniaTest/AvaloniaTest.csproj
@@ -3,9 +3,6 @@
     <TargetFramework>FrameworkParameter</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
   
   <ItemGroup>

--- a/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/dotnetcli.host.json
@@ -16,9 +16,6 @@
     },
     "MVVMToolkit": {
       "longName": "mvvm"
-    },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
     }
   },
   "usageExamples": [

--- a/templates/fsharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/fsharp/app-mvvm/.template.config/ide.host.json
@@ -17,13 +17,6 @@
       "isVisible": true
     },
     {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
-    },
-    {
       "id": "RemoveViewLocator",
       "name": {
         "text": "Remove View Locator"

--- a/templates/fsharp/app-mvvm/.template.config/template.json
+++ b/templates/fsharp/app-mvvm/.template.config/template.json
@@ -73,13 +73,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "RemoveViewLocator": {
       "type": "parameter",
       "description": "Defines if your app will use default ViewLocator made by Avalonia Team or you are planning to use a custom one. Removing ViewLocator may be useful in code trimming scenarios. Default ViewLocator is not trimming-friendly.",

--- a/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app-mvvm/AvaloniaAppTemplate.fsproj
@@ -3,9 +3,6 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>FrameworkParameter</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/fsharp/app/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/app/.template.config/dotnetcli.host.json
@@ -10,9 +10,6 @@
     },
     "AvaloniaVersion": {
       "longName": "avalonia-version"
-    },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
     }
   },
   "usageExamples": [

--- a/templates/fsharp/app/.template.config/ide.host.json
+++ b/templates/fsharp/app/.template.config/ide.host.json
@@ -8,13 +8,6 @@
         "text": "Avalonia Version"
       },
       "isVisible": false
-    },
-    {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
     }
   ]
 }

--- a/templates/fsharp/app/.template.config/template.json
+++ b/templates/fsharp/app/.template.config/template.json
@@ -49,13 +49,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "HostIdentifier": {
       "type": "bind",
       "binding": "HostIdentifier"

--- a/templates/fsharp/app/AvaloniaAppTemplate.fsproj
+++ b/templates/fsharp/app/AvaloniaAppTemplate.fsproj
@@ -3,9 +3,6 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>FrameworkParameter</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/fsharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/xplat/.template.config/dotnetcli.host.json
@@ -7,9 +7,6 @@
     "AvaloniaVersion": {
       "longName": "avalonia-version"
     },
-    "UseCompiledBindings": {
-      "longName": "compiled-bindings"
-    },
     "MVVMToolkit": {
       "longName": "mvvm"
     },

--- a/templates/fsharp/xplat/.template.config/ide.host.json
+++ b/templates/fsharp/xplat/.template.config/ide.host.json
@@ -17,13 +17,6 @@
       "isVisible": true
     },
     {
-      "id": "UseCompiledBindings",
-      "name": {
-        "text": "Use Compiled Bindings"
-      },
-      "isVisible": true
-    },
-    {
       "id": "MainViewPageType",
       "name": {
         "text": "Main View Page Type"

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -117,13 +117,6 @@
       "replaces": "AvaloniaVersionTemplateParameter",
       "defaultValue": "12.0.5"
     },
-    "UseCompiledBindings": {
-      "type": "parameter",
-      "description": "Defines if CompiledBindings should be enabled by default in the project (only supported in 11.0 version and newer).",
-      "datatype": "bool",
-      "displayName": "Use compiled Bindings",
-      "defaultValue": "true"
-    },
     "RemoveViewLocator": {
       "type": "parameter",
       "description": "Defines if your app will use default ViewLocator made by Avalonia Team or you are planning to use a custom one. Removing ViewLocator may be useful in code trimming scenarios. Default ViewLocator is not trimming-friendly.",

--- a/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest/AvaloniaTest.fsproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFramework>FrameworkParameter</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <!--#if (UseCompiledBindings) -->
-    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <!--#endif -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -117,16 +117,12 @@ $binlog = [IO.Path]::GetFullPath([IO.Path]::Combine($pwd, "..", "binlog", "test.
 
 Create-And-Build "avalonia.app" "AvaloniaApp" "C#" "f" "net10.0" $binlog
 Create-And-Build "avalonia.app" "AvaloniaApp" "C#" "av" "12.0.5" $binlog
-Create-And-Build "avalonia.app" "AvaloniaApp" "C#" "cb" "true" $binlog
-Create-And-Build "avalonia.app" "AvaloniaApp" "C#" "cb" "false" $binlog
 
 # Build the project only twice with all item templates,once with .net6.0 tfm and once with .net7.0 tfm for C# and F#
 Test-Template "avalonia.mvvm" "AvaloniaMvvm" "C#" "f" "net10.0" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "av" "12.0.5" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "m" "ReactiveUI" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "m" "CommunityToolkit" $binlog
-Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "cb" "true" $binlog
-Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "cb" "false" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "rvl" "true" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "C#" "rvl" "false" $binlog
 
@@ -136,8 +132,6 @@ Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "cpm" "false" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "av" "12.0.5" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "m" "ReactiveUI" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "m" "CommunityToolkit" $binlog
-Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "cb" "true" $binlog
-Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "cb" "false" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "rvl" "true" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "C#" "rvl" "false" $binlog
 
@@ -146,15 +140,11 @@ Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "output/C#"
 
 Create-And-Build "avalonia.app" "AvaloniaApp" "F#" "f" "net10.0" $binlog
 Create-And-Build "avalonia.app" "AvaloniaApp" "F#" "av" "12.0.5" $binlog
-Create-And-Build "avalonia.app" "AvaloniaApp" "F#" "cb" "true" $binlog
-Create-And-Build "avalonia.app" "AvaloniaApp" "F#" "cb" "false" $binlog
 
 Test-Template "avalonia.mvvm" "AvaloniaMvvm" "F#" "f" "net10.0" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "av" "12.0.5" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "m" "ReactiveUI" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "m" "CommunityToolkit" $binlog
-Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "cb" "true" $binlog
-Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "cb" "false" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "rvl" "true" $binlog
 Create-And-Build "avalonia.mvvm" "AvaloniaMvvm" "F#" "rvl" "false" $binlog
 
@@ -162,8 +152,6 @@ Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "f" "net10.0" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "av" "12.0.5" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "m" "ReactiveUI" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "m" "CommunityToolkit" $binlog
-Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "cb" "true" $binlog
-Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "cb" "false" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "true" $binlog
 Create-And-Build "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "false" $binlog
 


### PR DESCRIPTION
Starting with 12.0 this parameter is enabled by default, and we want to discourage users from defaulting to reflection bindings.

Any new project that wants to use reflection bindings by default still can do that by setting `<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>` directly in the project.
For everybody else we recommend using compiled bindings by default, and falling back to reflection binding only where it's necessary (by explicitly using `{ReflectionBinding Path}` syntax).