### PR TITLE
Add page templates tests and several bug fixes

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
@@ -1,5 +1,8 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
+#if (!DefaultMainPageChosen)
+using Avalonia.Controls;
+#endif
 #if (CommunityToolkitChosen)
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
@@ -31,10 +34,10 @@ public partial class App : Application
         {
 #if (DefaultMainPageChosen)
             singleViewFactoryApplicationLifetime.MainViewFactory = () => new MainView { DataContext = new MainViewModel() };
-#else            
+#else
             singleViewFactoryApplicationLifetime.MainViewFactory = () => new PageNavigationHost()
             {
-                Page = new MainView { DataContext = new MainWindowViewModel() }
+                Page = new MainView { DataContext = new MainViewModel() }
             };
 #endif
         }
@@ -45,10 +48,10 @@ public partial class App : Application
             {
                 DataContext = new MainViewModel()
             };
-#else            
+#else
             singleViewPlatform.MainView = new PageNavigationHost()
             {
-                Page = new MainView { DataContext = new MainWindowViewModel() }
+                Page = new MainView { DataContext = new MainViewModel() }
             };
 #endif
         }

--- a/templates/fsharp/contentpage/.template.config/template.json
+++ b/templates/fsharp/contentpage/.template.config/template.json
@@ -5,7 +5,7 @@
   "defaultName": "ContentPage",
   "description": "An Avalonia UI ContentPage",
   "groupidentity": "Avalonia.ContentPage",
-  "identity": "Avalonia.ContentPage",
+  "identity": "Avalonia.ContentPage.FSharp",
   "name": "Avalonia ContentPage",
   "primaryOutputs": [
     { "path": "NewContentPage.axaml.fs" },

--- a/templates/fsharp/drawerpage/.template.config/template.json
+++ b/templates/fsharp/drawerpage/.template.config/template.json
@@ -5,7 +5,7 @@
   "defaultName": "DrawerPage",
   "description": "An Avalonia UI DrawerPage",
   "groupidentity": "Avalonia.DrawerPage",
-  "identity": "Avalonia.DrawerPage",
+  "identity": "Avalonia.DrawerPage.FSharp",
   "name": "Avalonia DrawerPage",
   "primaryOutputs": [
     { "path": "NewDrawerPage.axaml.fs" },

--- a/templates/fsharp/navigationpage/.template.config/template.json
+++ b/templates/fsharp/navigationpage/.template.config/template.json
@@ -5,7 +5,7 @@
   "defaultName": "NavigationPage",
   "description": "An Avalonia UI NavigationPage",
   "groupidentity": "Avalonia.NavigationPage",
-  "identity": "Avalonia.NavigationPage",
+  "identity": "Avalonia.NavigationPage.FSharp",
   "name": "Avalonia NavigationPage",
   "primaryOutputs": [
     { "path": "NewNavigationPage.axaml.fs" },

--- a/templates/fsharp/tabbedpage/.template.config/template.json
+++ b/templates/fsharp/tabbedpage/.template.config/template.json
@@ -5,7 +5,7 @@
   "defaultName": "TabbedPage",
   "description": "An Avalonia UI TabbedPage",
   "groupidentity": "Avalonia.TabbedPage",
-  "identity": "Avalonia.TabbedPage",
+  "identity": "Avalonia.TabbedPage.FSharp",
   "name": "Avalonia TabbedPage",
   "primaryOutputs": [
     { "path": "NewTabbedPage.axaml.fs" },

--- a/templates/fsharp/xplat/.template.config/dotnetcli.host.json
+++ b/templates/fsharp/xplat/.template.config/dotnetcli.host.json
@@ -10,10 +10,6 @@
     "MVVMToolkit": {
       "longName": "mvvm"
     },
-    "MainViewPageType": {
-      "longName": "main-view-page-type",
-      "shortName": "page"
-    },
     "RemoveViewLocator": {
       "longName": "remove-view-locator"
     }

--- a/templates/fsharp/xplat/.template.config/ide.host.json
+++ b/templates/fsharp/xplat/.template.config/ide.host.json
@@ -17,13 +17,6 @@
       "isVisible": true
     },
     {
-      "id": "MainViewPageType",
-      "name": {
-        "text": "Main View Page Type"
-      },
-      "isVisible": true
-    },
-    {
       "id": "RemoveViewLocator",
       "name": {
         "text": "Remove View Locator"

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -52,35 +52,6 @@
         }
       ],
       "defaultValue": "CommunityToolkit"
-    },    
-    "MainViewPageType": {
-      "type": "parameter",
-      "displayName": "Main View Page Type",
-      "description": "The type of main view page to create.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "None",
-          "description": "Create the main view as a UserControl"
-        },
-        {
-          "choice": "ContentPage",
-          "description": "Create the main view as a ContentPage"
-        },
-        {
-          "choice": "TabbedPage",
-          "description": "Create the main view as a TabbedPage"
-        },
-        {
-          "choice": "DrawerPage",
-          "description": "Create the main view as a DrawerPage with a child NavigationPage"
-        },
-        {
-          "choice": "NavigationPage",
-          "description": "Create the main view as a NavigationPage"
-        }
-      ],
-      "defaultValue": "None"
     },
     "ReactiveUIToolkitChosen": {
       "type": "computed",
@@ -89,26 +60,6 @@
     "CommunityToolkitChosen": {
       "type": "computed",
       "value": "(MVVMToolkit == \"CommunityToolkit\")"
-    },
-    "DefaultMainPageChosen": {
-      "type": "computed",
-      "value": "(MainViewPageType == \"None\")"
-    },
-    "ContentMainPageChosen": {
-      "type": "computed",
-      "value": "(MainViewPageType == \"ContentPage\")"
-    },
-    "TabbedMainPageChosen": {
-      "type": "computed",
-      "value": "(MainViewPageType == \"TabbedPage\")"
-    },
-    "DrawerMainPageChosen": {
-      "type": "computed",
-      "value": "(MainViewPageType == \"DrawerPage\")"
-    },
-    "NavigationMainPageChosen": {
-      "type": "computed",
-      "value": "(MainViewPageType == \"NavigationPage\")"
     },
     "AvaloniaVersion": {
       "type": "parameter",

--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -82,10 +82,6 @@ $builds = @(
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "m"   "CommunityToolkit"
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "true"
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "false"
-    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "ContentPage"
-    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "TabbedPage"
-    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "DrawerPage"
-    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "NavigationPage"
 )
 
 $itemTemplates = @(

--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -61,6 +61,10 @@ $builds = @(
     New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "m"   "CommunityToolkit"
     New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "rvl" "true"
     New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "rvl" "false"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "page" "ContentPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "page" "TabbedPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "page" "DrawerPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "C#" "page" "NavigationPage"
 
     New-Case "avalonia.app"   "AvaloniaApp"   "F#" "f"   "net10.0"
     New-Case "avalonia.app"   "AvaloniaApp"   "F#" "av"  "12.0.5"
@@ -78,13 +82,22 @@ $builds = @(
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "m"   "CommunityToolkit"
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "true"
     New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "rvl" "false"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "ContentPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "TabbedPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "DrawerPage"
+    New-Case "avalonia.xplat" "AvaloniaXplat" "F#" "page" "NavigationPage"
 )
 
 $itemTemplates = @(
-    New-ItemCase "avalonia.resource"    "NewResourceDictionary"
-    New-ItemCase "avalonia.styles"      "NewStyles"
-    New-ItemCase "avalonia.usercontrol" "NewUserControl" -HasCodeBehind
-    New-ItemCase "avalonia.window"      "NewWindow"      -HasCodeBehind
+    New-ItemCase "avalonia.resource"         "NewResourceDictionary"
+    New-ItemCase "avalonia.styles"           "NewStyles"
+    New-ItemCase "avalonia.usercontrol"      "NewUserControl"      -HasCodeBehind
+    New-ItemCase "avalonia.window"           "NewWindow"           -HasCodeBehind
+    New-ItemCase "avalonia.templatedcontrol" "NewTemplatedControl" -HasCodeBehind
+    New-ItemCase "avalonia.contentpage"      "NewContentPage"      -HasCodeBehind
+    New-ItemCase "avalonia.drawerpage"       "NewDrawerPage"       -HasCodeBehind
+    New-ItemCase "avalonia.navigationpage"   "NewNavigationPage"   -HasCodeBehind
+    New-ItemCase "avalonia.tabbedpage"       "NewTabbedPage"       -HasCodeBehind
 )
 
 Write-Output "Clearing outputs from possible previous runs"


### PR DESCRIPTION
1. Page parameters were not tested
2. C# XPlat template wasn't compileable with new parameters
3. F# item templates had a duplicated IDs
4. F# XPlat template had unimplemented "page" parameter - removed from this PR completely.

Fixes https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/340