### PR TITLE
Two way binding in mvvm templates

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/template.json
+++ b/templates/csharp/app-mvvm/.template.config/template.json
@@ -66,6 +66,10 @@
       "type": "computed",
       "value": "(MVVMToolkit == \"CommunityToolkit\")"
     },
+    "UsePartialProperties": {
+      "type": "computed",
+      "value": "(Framework != \"net8.0\" && Framework != \"net9.0\")"
+    },
     "AvaloniaVersion": {
       "type": "parameter",
       "description": "The target version of Avalonia NuGet packages.",

--- a/templates/csharp/app-mvvm/ViewModels/MainViewModel.cs
+++ b/templates/csharp/app-mvvm/ViewModels/MainViewModel.cs
@@ -1,10 +1,30 @@
-﻿namespace AvaloniaAppTemplate.ViewModels;
+#if (CommunityToolkitChosen)
+using CommunityToolkit.Mvvm.ComponentModel;
+#elif (ReactiveUIToolkitChosen)
+using ReactiveUI;
+#endif
+
+namespace AvaloniaAppTemplate.ViewModels;
 
 #if (CommunityToolkitChosen)
 public partial class MainViewModel : ViewModelBase
-#else
-public class MainViewModel : ViewModelBase
-#endif
 {
-    public string Greeting { get; } = "Welcome to Avalonia!";
+    [ObservableProperty]
+#if (UsePartialProperties)
+    public partial string Greeting { get; set; } = "Welcome to Avalonia!";
+#else
+    private string _greeting = "Welcome to Avalonia!";
+#endif
 }
+#elif (ReactiveUIToolkitChosen)
+public class MainViewModel : ViewModelBase
+{
+    private string _greeting = "Welcome to Avalonia!";
+
+    public string Greeting
+    {
+        get => _greeting;
+        set => this.RaiseAndSetIfChanged(ref _greeting, value);
+    }
+}
+#endif

--- a/templates/csharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/csharp/app-mvvm/Views/MainWindow.axaml
@@ -15,6 +15,7 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <TextBox Text="{Binding Greeting, Mode=TwoWay}" Width="200"
+             HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
 </Window>

--- a/templates/csharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/csharp/app-mvvm/Views/MainWindow.axaml
@@ -15,7 +15,7 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <TextBox Text="{Binding Greeting, Mode=TwoWay}" Width="200"
+    <TextBox Text="{Binding Greeting}" Width="200"
              HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
 </Window>

--- a/templates/csharp/xplat/.template.config/template.json
+++ b/templates/csharp/xplat/.template.config/template.json
@@ -22,14 +22,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
-        },
-        {
-          "choice": "net9.0",
-          "description": "Target net9.0"
-        },
-        {
           "choice": "net10.0",
           "description": "Target net10.0"
         }

--- a/templates/csharp/xplat/AvaloniaTest/ViewModels/HomeViewModel.cs
+++ b/templates/csharp/xplat/AvaloniaTest/ViewModels/HomeViewModel.cs
@@ -1,19 +1,26 @@
-﻿#if (CommunityToolkitChosen)
+#if (CommunityToolkitChosen)
 using CommunityToolkit.Mvvm.ComponentModel;
+#elif (ReactiveUIToolkitChosen)
+using ReactiveUI;
 #endif
 
 namespace AvaloniaTest.ViewModels;
 
 #if (CommunityToolkitChosen)
 public partial class HomeViewModel : ViewModelBase
-#else
-public class HomeViewModel : ViewModelBase
-#endif
 {
-#if (CommunityToolkitChosen)
     [ObservableProperty]
-    private string _greeting = "Welcome to Avalonia!";
-#else
-    public string Greeting { get; } = "Welcome to Avalonia!";
-#endif
+    public partial string Greeting { get; set; } = "Welcome to Avalonia!";
 }
+#elif (ReactiveUIToolkitChosen)
+public class HomeViewModel : ViewModelBase
+{
+    private string _greeting = "Welcome to Avalonia!";
+
+    public string Greeting
+    {
+        get => _greeting;
+        set => this.RaiseAndSetIfChanged(ref _greeting, value);
+    }
+}
+#endif

--- a/templates/csharp/xplat/AvaloniaTest/ViewModels/MainViewModel.cs
+++ b/templates/csharp/xplat/AvaloniaTest/ViewModels/MainViewModel.cs
@@ -1,19 +1,26 @@
-﻿#if (CommunityToolkitChosen)
+#if (CommunityToolkitChosen)
 using CommunityToolkit.Mvvm.ComponentModel;
+#elif (ReactiveUIToolkitChosen)
+using ReactiveUI;
 #endif
 
 namespace AvaloniaTest.ViewModels;
 
 #if (CommunityToolkitChosen)
 public partial class MainViewModel : ViewModelBase
-#else
-public class MainViewModel : ViewModelBase
-#endif
 {
-#if (CommunityToolkitChosen)
     [ObservableProperty]
-    private string _greeting = "Welcome to Avalonia!";
-#else
-    public string Greeting { get; } = "Welcome to Avalonia!";
-#endif
+    public partial string Greeting { get; set; } = "Welcome to Avalonia!";
 }
+#elif (ReactiveUIToolkitChosen)
+public class MainViewModel : ViewModelBase
+{
+    private string _greeting = "Welcome to Avalonia!";
+
+    public string Greeting
+    {
+        get => _greeting;
+        set => this.RaiseAndSetIfChanged(ref _greeting, value);
+    }
+}
+#endif

--- a/templates/csharp/xplat/AvaloniaTest/ViewModels/SettingsViewModel.cs
+++ b/templates/csharp/xplat/AvaloniaTest/ViewModels/SettingsViewModel.cs
@@ -1,19 +1,26 @@
-﻿#if (CommunityToolkitChosen)
+#if (CommunityToolkitChosen)
 using CommunityToolkit.Mvvm.ComponentModel;
+#elif (ReactiveUIToolkitChosen)
+using ReactiveUI;
 #endif
 
 namespace AvaloniaTest.ViewModels;
 
 #if (CommunityToolkitChosen)
 public partial class SettingsViewModel : ViewModelBase
-#else
-public class SettingsViewModel : ViewModelBase
-#endif
 {
-#if (CommunityToolkitChosen)
     [ObservableProperty]
-    private string _greeting = "This is Settings";
-#else
-    public string Greeting { get; } = "This is Settings";
-#endif
+    public partial string Greeting { get; set; } = "This is Settings";
 }
+#elif (ReactiveUIToolkitChosen)
+public class SettingsViewModel : ViewModelBase
+{
+    private string _greeting = "This is Settings";
+
+    public string Greeting
+    {
+        get => _greeting;
+        set => this.RaiseAndSetIfChanged(ref _greeting, value);
+    }
+}
+#endif

--- a/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
@@ -15,7 +15,7 @@
     <StackPanel HorizontalAlignment="Center" 
                 VerticalAlignment="Center"
                 Spacing="10">
-        <TextBox Text="{Binding Greeting}" Width="200" />
+        <TextBox Text="{Binding Greeting}" />
     <Button Name="SettingButton" HorizontalAlignment="Center" Click="SettingButton_Click">Open Settings</Button>
     </StackPanel>
 </ContentPage>

--- a/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
@@ -15,7 +15,7 @@
     <StackPanel HorizontalAlignment="Center" 
                 VerticalAlignment="Center"
                 Spacing="10">
-        <TextBlock Text="{Binding Greeting}" />	
+        <TextBox Text="{Binding Greeting}" Width="200" />
     <Button Name="SettingButton" HorizontalAlignment="Center" Click="SettingButton_Click">Open Settings</Button>
     </StackPanel>
 </ContentPage>

--- a/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -56,7 +56,7 @@ to set the actual DataContext for runtime, set the DataContext property in code 
         <ContentPage.Icon>
             <PathIcon Data="{StaticResource HomeIcon}"/>
         </ContentPage.Icon>
-        <TextBlock Text="{Binding Greeting}"
+        <TextBox Text="{Binding Greeting}" Width="200"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"/>
     </ContentPage>
@@ -132,7 +132,7 @@ to set the actual DataContext for runtime, set the DataContext property in code 
                     <ContentPage.Icon>
                         <PathIcon Data="{StaticResource SettingsIcon}"/>
                     </ContentPage.Icon>
-                    <TextBlock Text="{Binding Greeting}"
+                    <TextBox Text="{Binding Greeting}" Width="200"
                             HorizontalAlignment="Center"
                                     VerticalAlignment="Center"/>
                 </ContentPage>
@@ -141,7 +141,7 @@ to set the actual DataContext for runtime, set the DataContext property in code 
     </ContentPage>
 <!--#elif (NavigationMainPageChosen) -->
 <!--#else-->
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 <!--#endif -->
 <!--#if (ContentMainPageChosen) -->
 </ContentPage>

--- a/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -56,9 +56,9 @@ to set the actual DataContext for runtime, set the DataContext property in code 
         <ContentPage.Icon>
             <PathIcon Data="{StaticResource HomeIcon}"/>
         </ContentPage.Icon>
-        <TextBox Text="{Binding Greeting}" Width="200"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"/>
+        <TextBox Text="{Binding Greeting}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"/>
     </ContentPage>
     <ContentPage Header="Settings">
         <ContentPage.Icon>
@@ -132,16 +132,16 @@ to set the actual DataContext for runtime, set the DataContext property in code 
                     <ContentPage.Icon>
                         <PathIcon Data="{StaticResource SettingsIcon}"/>
                     </ContentPage.Icon>
-                    <TextBox Text="{Binding Greeting}" Width="200"
-                            HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"/>
+                    <TextBox Text="{Binding Greeting}"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center"/>
                 </ContentPage>
             </DataTemplate>
         </ContentPage.DataTemplates>
     </ContentPage>
 <!--#elif (NavigationMainPageChosen) -->
 <!--#else-->
-    <TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <TextBox Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 <!--#endif -->
 <!--#if (ContentMainPageChosen) -->
 </ContentPage>

--- a/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
@@ -12,6 +12,6 @@
 		to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
 		<vm:HomeViewModel />
 	</Design.DataContext>
-	<TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center"
+	<TextBox Text="{Binding Greeting}" HorizontalAlignment="Center"
 			   VerticalAlignment="Center" />
 </ContentPage>

--- a/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
@@ -12,6 +12,6 @@
 		to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
 		<vm:HomeViewModel />
 	</Design.DataContext>
-	<TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center"
+	<TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center"
 			   VerticalAlignment="Center" />
 </ContentPage>

--- a/templates/csharp/xplat/Directory.Packages.props
+++ b/templates/csharp/xplat/Directory.Packages.props
@@ -18,7 +18,7 @@
         <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8" />
         <!--#elif (CommunityToolkitChosen)-->
 
-        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.1" />
         <!--#endif -->
 
         <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.15" />

--- a/templates/fsharp/app-mvvm/ViewModels/MainViewModel.fs
+++ b/templates/fsharp/app-mvvm/ViewModels/MainViewModel.fs
@@ -1,6 +1,18 @@
-﻿namespace AvaloniaAppTemplate.ViewModels
+namespace AvaloniaAppTemplate.ViewModels
+
+#if (ReactiveUIToolkitChosen)
+open ReactiveUI
+#endif
 
 type MainViewModel() =
     inherit ViewModelBase()
 
-    member this.Greeting = "Welcome to Avalonia!"
+    let mutable greeting = "Welcome to Avalonia!"
+
+    member this.Greeting
+        with get () = greeting
+#if (CommunityToolkitChosen)
+        and set value = this.SetProperty(&greeting, value) |> ignore
+#elif (ReactiveUIToolkitChosen)
+        and set value = this.RaiseAndSetIfChanged(&greeting, value) |> ignore
+#endif

--- a/templates/fsharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/fsharp/app-mvvm/Views/MainWindow.axaml
@@ -15,6 +15,7 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <TextBox Text="{Binding Greeting, Mode=TwoWay}" Width="200"
+             HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
 </Window>

--- a/templates/fsharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/fsharp/app-mvvm/Views/MainWindow.axaml
@@ -15,7 +15,7 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <TextBox Text="{Binding Greeting, Mode=TwoWay}" Width="200"
+    <TextBox Text="{Binding Greeting}" Width="200"
              HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
 </Window>

--- a/templates/fsharp/app-mvvm/Views/MainWindow.axaml
+++ b/templates/fsharp/app-mvvm/Views/MainWindow.axaml
@@ -15,7 +15,7 @@
         <vm:MainViewModel/>
     </Design.DataContext>
 
-    <TextBox Text="{Binding Greeting}" Width="200"
+    <TextBox Text="{Binding Greeting}"
              HorizontalAlignment="Center" VerticalAlignment="Center"/>
 
 </Window>

--- a/templates/fsharp/xplat/.template.config/template.json
+++ b/templates/fsharp/xplat/.template.config/template.json
@@ -22,14 +22,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net8.0",
-          "description": "Target net8.0"
-        },
-        {
-          "choice": "net9.0",
-          "description": "Target net9.0"
-        },
-        {
           "choice": "net10.0",
           "description": "Target net10.0"
         }

--- a/templates/fsharp/xplat/AvaloniaTest/ViewModels/MainViewModel.fs
+++ b/templates/fsharp/xplat/AvaloniaTest/ViewModels/MainViewModel.fs
@@ -1,6 +1,18 @@
-﻿namespace AvaloniaTest.ViewModels
+namespace AvaloniaTest.ViewModels
+
+#if (ReactiveUIToolkitChosen)
+open ReactiveUI
+#endif
 
 type MainViewModel() =
     inherit ViewModelBase()
 
-    member this.Greeting = "Welcome to Avalonia!"
+    let mutable greeting = "Welcome to Avalonia!"
+
+    member this.Greeting
+        with get () = greeting
+#if (CommunityToolkitChosen)
+        and set value = this.SetProperty(&greeting, value) |> ignore
+#elif (ReactiveUIToolkitChosen)
+        and set value = this.RaiseAndSetIfChanged(&greeting, value) |> ignore
+#endif

--- a/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -12,5 +12,5 @@
     <vm:MainViewModel />
   </Design.DataContext>
 
-  <TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+  <TextBox Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 </UserControl>

--- a/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
+++ b/templates/fsharp/xplat/AvaloniaTest/Views/MainView.axaml
@@ -12,5 +12,5 @@
     <vm:MainViewModel />
   </Design.DataContext>
 
-  <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+  <TextBox Text="{Binding Greeting}" Width="200" HorizontalAlignment="Center" VerticalAlignment="Center"/>
 </UserControl>

--- a/tests/build-test.ps1
+++ b/tests/build-test.ps1
@@ -47,6 +47,7 @@ $builds = @(
     New-Case "avalonia.app"   "AvaloniaApp"   "C#" "av"  "12.0.5"
 
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "C#" "f"   "net10.0" -Items
+    New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "C#" "f"   "net8.0"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "C#" "av"  "12.0.5"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "C#" "m"   "ReactiveUI"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "C#" "m"   "CommunityToolkit"
@@ -70,6 +71,7 @@ $builds = @(
     New-Case "avalonia.app"   "AvaloniaApp"   "F#" "av"  "12.0.5"
 
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "F#" "f"   "net10.0" -Items
+    New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "F#" "f"   "net8.0"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "F#" "av"  "12.0.5"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "F#" "m"   "ReactiveUI"
     New-Case "avalonia.mvvm"  "AvaloniaMvvm"  "F#" "m"   "CommunityToolkit"


### PR DESCRIPTION
Fixes https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/93

Replace OneWay TextBlock binding with TwoWay TextBox binding in our MVVM templates, making a better use case to get started (including INPC)

Typical diff:
```diff
public partial class MainViewModel : ViewModelBase
{
-    public string Greeting { get; } = "Welcome to Avalonia!";
+    [ObservableProperty]
+    public partial string Greeting { get; set; } = "Welcome to Avalonia!";
}
```
```diff
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <TextBox Text="{Binding Greeting}"
+             HorizontalAlignment="Center" VerticalAlignment="Center"/>
```
