### PR TITLE
Move DevTools init to the shared XPlat project

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest.Browser/Program.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Browser/Program.cs
@@ -11,11 +11,6 @@ internal sealed partial class Program
 {
     private static Task Main(string[] args) => BuildAvaloniaApp()
             .WithInterFont()
-//-:cnd:noEmit
-#if DEBUG
-            .WithDeveloperTools()
-#endif
-//+:cnd:noEmit
 #if (ReactiveUIToolkitChosen)
             .UseReactiveUI(_ => { })
 #endif

--- a/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.csproj
@@ -14,16 +14,8 @@
   <ItemGroup>
     <!--#if (UseCentralPackageManagement) -->
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" >
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
     <!--#else -->
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
     <!--#endif -->
   </ItemGroup>
 

--- a/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
+++ b/templates/csharp/xplat/AvaloniaTest.Desktop/Program.cs
@@ -19,11 +19,6 @@ sealed class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-//-:cnd:noEmit
-#if DEBUG
-            .WithDeveloperTools()
-#endif
-//+:cnd:noEmit
             .WithInterFont()
 #if (ReactiveUIToolkitChosen)
             .UseReactiveUI(_ => { })

--- a/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/App.axaml.cs
@@ -19,6 +19,11 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+//-:cnd:noEmit
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
+//+:cnd:noEmit
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/templates/csharp/xplat/Directory.Packages.props
+++ b/templates/csharp/xplat/Directory.Packages.props
@@ -9,11 +9,11 @@
         <PackageVersion Include="Avalonia" Version="AvaloniaVersionTemplateParameter" />
         <PackageVersion Include="Avalonia.Themes.Fluent" Version="AvaloniaVersionTemplateParameter" />
         <PackageVersion Include="Avalonia.Fonts.Inter" Version="AvaloniaVersionTemplateParameter" />
-        <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
         <PackageVersion Include="Avalonia.Desktop" Version="AvaloniaVersionTemplateParameter" />
         <PackageVersion Include="Avalonia.iOS" Version="AvaloniaVersionTemplateParameter" />
         <PackageVersion Include="Avalonia.Browser" Version="AvaloniaVersionTemplateParameter" />
         <PackageVersion Include="Avalonia.Android" Version="AvaloniaVersionTemplateParameter" />
+        <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
         <!--#if (ReactiveUIToolkitChosen) -->
         <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
         <!--#elif (CommunityToolkitChosen)-->

--- a/templates/fsharp/xplat/AvaloniaTest.Browser/Program.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.Browser/Program.fs
@@ -20,11 +20,6 @@ module Program =
         task {
             do! (buildAvaloniaApp()
             .WithInterFont()
-//-:cnd:noEmit
-#if DEBUG
-            .WithDeveloperTools()
-#endif
-//+:cnd:noEmit
 #if (ReactiveUIToolkitChosen)
             .UseReactiveUI(fun _ -> ())
 #endif

--- a/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
+++ b/templates/fsharp/xplat/AvaloniaTest.Desktop/AvaloniaTest.Desktop.fsproj
@@ -16,10 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
-      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/fsharp/xplat/AvaloniaTest.Desktop/Program.fs
+++ b/templates/fsharp/xplat/AvaloniaTest.Desktop/Program.fs
@@ -13,11 +13,6 @@ module Program =
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
-//-:cnd:noEmit
-#if DEBUG
-            .WithDeveloperTools()
-#endif
-//+:cnd:noEmit
             .WithInterFont()
             .LogToTrace(areas = Array.empty)
 #if (ReactiveUIToolkitChosen)

--- a/templates/fsharp/xplat/AvaloniaTest/App.axaml.fs
+++ b/templates/fsharp/xplat/AvaloniaTest/App.axaml.fs
@@ -15,6 +15,11 @@ type App() =
 
     override this.Initialize() =
             AvaloniaXamlLoader.Load(this)
+//-:cnd:noEmit
+#if DEBUG
+            this.AttachDeveloperTools() |> ignore
+#endif
+//+:cnd:noEmit
 
     override this.OnFrameworkInitializationCompleted() =
         match this.ApplicationLifetime with


### PR DESCRIPTION
Closes https://github.com/AvaloniaUI/avalonia-dotnet-templates/issues/334

Allows to use it from mobile/browser projects, with some additional setup (see [DevTools / Attaching applications](https://docs.avaloniaui.net/tools/developer-tools/attaching-applications)).

