### PR TITLE
Mark VS as an unsupported IDE for the Shared & C# templates

### DIFF
--- a/templates/csharp/app-mvvm/.template.config/ide.host.json
+++ b/templates/csharp/app-mvvm/.template.config/ide.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "symbolInfo": [
     {
@@ -23,5 +23,6 @@
       },
       "isVisible": true
     }
-  ]
+  ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/app/.template.config/ide.host.json
+++ b/templates/csharp/app/.template.config/ide.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "symbolInfo": [
     {
@@ -9,5 +9,6 @@
       },
       "isVisible": false
     }
-  ]
+  ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/contentpage/.template.config/ide.host.json
+++ b/templates/csharp/contentpage/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/drawerpage/.template.config/ide.host.json
+++ b/templates/csharp/drawerpage/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/navigationpage/.template.config/ide.host.json
+++ b/templates/csharp/navigationpage/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/tabbedpage/.template.config/ide.host.json
+++ b/templates/csharp/tabbedpage/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/templatedcontrol/.template.config/ide.host.json
+++ b/templates/csharp/templatedcontrol/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/usercontrol/.template.config/ide.host.json
+++ b/templates/csharp/usercontrol/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/window/.template.config/ide.host.json
+++ b/templates/csharp/window/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/csharp/xplat/.template.config/ide.host.json
+++ b/templates/csharp/xplat/.template.config/ide.host.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "symbolInfo": [
     {
@@ -37,5 +37,6 @@
       },
       "isVisible": true
     }
-  ]
+  ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/resource-dictionary/.template.config/ide.host.json
+++ b/templates/resource-dictionary/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }

--- a/templates/styles/.template.config/ide.host.json
+++ b/templates/styles/.template.config/ide.host.json
@@ -1,6 +1,7 @@
 {
-  "$schema": "http://json.schemastore.org/ide.host",
+  "$schema": "https://json.schemastore.org/ide.host",
   "icon": "icon.png",
   "defaultItemExtension": "axaml",
-  "itemHierarchyPaths": [ "Avalonia" ]
+  "itemHierarchyPaths": [ "Avalonia" ],
+  "unsupportedHosts": [{ "id": "vs" }]
 }


### PR DESCRIPTION
To address the issues relating to problems with the templates when used from within Visual Studio (#255 #244 #235 & #165), we will ship different templates in future versions of the VS extension. (Using a different system that allows us to avoid such problems.)

This PR ensures that the templates here will no longer show in VS when they are also installed on the machine. This stops both versions from being displayed in the "New Project" and "New Item" dialogs. 
If/when they are both shown:
- it looks broken
- determining between the different versions is difficult
- people may (accidentally) use the versions that don't include the fix.


The changes presented here do not have any impact on using these templates with any other IDE or from the command line.



This PR also includes updates to the schema URLs of the files changed. This is to allow tools (VS & VSCode) to use the schema while editing the files.