### PR TITLE
Address inconsistency in views for NavigationPage in XPlat project

### DIFF
--- a/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              Header="Home"
              x:DataType="vm:HomeViewModel"
-             x:Class="AvaloniaTest.HomeView">
+             x:Class="AvaloniaTest.Views.HomeView">
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,
              to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->

--- a/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/Views/HomeView.axaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using AvaloniaTest.ViewModels;
 
-namespace AvaloniaTest;
+namespace AvaloniaTest.Views;
 
 public partial class HomeView : ContentPage
 {

--- a/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
+++ b/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml
@@ -6,7 +6,7 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              Header="Settings"
              x:DataType="vm:SettingsViewModel"
-             x:Class="AvaloniaTest.SettingsView">
+             x:Class="AvaloniaTest.Views.SettingsView">
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,
              to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->

--- a/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml.cs
+++ b/templates/csharp/xplat/AvaloniaTest/Views/SettingsView.axaml.cs
@@ -2,7 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
-namespace AvaloniaTest;
+namespace AvaloniaTest.Views;
 
 public partial class SettingsView : ContentPage
 {


### PR DESCRIPTION
When creating a **Cross Platform** project and selecting `NavigationPage` as the "Main View Page Type", it creates 8 files in the "Views" directory, but these files use inconsistent namespace values.

`MainView` & `MainWindow` (`.xaml` and `.xaml.cs` versions) use the namespace of "{AssemblyName.}Views"

while 

`HomeView` & `SettingsView` (`.xaml` and `.xaml.cs` versions) use the namespace of "{AssemblyName}" (without the "Views" part)


The inconsistency can be seen with both the use of **CommunityToolkit** and **ReactiveUI** as the **MVVMToolkit** option.


This PR removes the inconsistency so that all files in the directory include `.Views` as part of the namespace.